### PR TITLE
check subtree for changes

### DIFF
--- a/build.make
+++ b/build.make
@@ -89,8 +89,23 @@ clean:
 	-rm -rf bin
 
 test:
+
+.PHONY: test-go
+test: test-go
+test-go:
+	@ echo; echo $@
 	go test `go list ./... | grep -v 'vendor'` $(TESTARGS)
+
+.PHONY: test-vet
+test: test-vet
+test-vet:
+	@ echo; echo $@
 	go vet `go list ./... | grep -v vendor`
+
+.PHONY: test-fmt
+test: test-fmt
+test-fmt:
+	@ echo; echo $@
 	files=$$(find . -name '*.go' | grep -v './vendor'); \
 	if [ $$(gofmt -d $$files | wc -l) -ne 0 ]; then \
 		echo "formatting errors:"; \

--- a/build.make
+++ b/build.make
@@ -112,3 +112,9 @@ test-fmt:
 		gofmt -d $$files; \
 		false; \
 	fi
+
+.PHONY: test-subtree
+test: test-subtree
+test-subtree:
+	@ echo; echo $@
+	./release-tools/verify-subtree.sh release-tools

--- a/travis.yml
+++ b/travis.yml
@@ -6,7 +6,7 @@ matrix:
   include:
   - go: 1.11.1
 script:
-- make all test
+- make -k all test
 after_success:
   - if [ "${TRAVIS_PULL_REQUEST}" == "false" ]; then
       docker login -u "${DOCKER_USERNAME}" -p "${DOCKER_PASSWORD}" quay.io;

--- a/verify-subtree.sh
+++ b/verify-subtree.sh
@@ -1,0 +1,41 @@
+#! /bin/sh -e
+#
+# Copyright 2019 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This script verifies that the content of a directory managed
+# by "git subtree" has not been modified locally. It does that
+# by looking for commits that modify the files with the
+# subtree prefix (aka directory) while ignoring merge
+# commits. Merge commits are where "git subtree" pulls the
+# upstream files into the directory.
+#
+# Theoretically a developer can subvert this check by modifying files
+# in a merge commit, but in practice that shouldn't happen.
+
+DIR="$1"
+if [ ! "$DIR" ]; then
+    echo "usage: $0 <directory>" >&2
+    exit 1
+fi
+
+REV=$(git log -n1 --format=format:%H --no-merges -- "$DIR")
+if [ "$REV" ]; then
+    echo "Directory '$DIR' contains non-upstream changes:"
+    echo
+    git log --no-merges -- "$DIR"
+    exit 1
+else
+    echo "$DIR is a clean copy of upstream."
+fi


### PR DESCRIPTION
This adds a check that prevents modifying the "release-tools" directory in sidecar repos.

Tested and discussed here: https://github.com/kubernetes-csi/external-attacher/pull/109#discussion_r250037619

/assign @msau42 