### PR TITLE
build.make: fix pushing of "canary" image from master branch

### DIFF
--- a/build.make
+++ b/build.make
@@ -70,7 +70,7 @@ push-%: container-%
 		docker push $(IMAGE_NAME):$$tag; \
 	}; \
 	for tag in $(IMAGE_TAGS); do \
-		if echo $$tag | grep -q -e '-canary$$'; then \
+		if [ "$$tag" = "canary" ] || echo "$$tag" | grep -q -e '-canary$$'; then \
 			: "creating or overwriting canary image"; \
 			push_image; \
 		elif docker pull $(IMAGE_NAME):$$tag 2>&1 | tee /dev/stderr | grep -q "manifest for $(IMAGE_NAME):$$tag not found"; then \


### PR DESCRIPTION
After merging into external-attacher, the next Travis CI run did not
push the "canary" image because the check for "canary" only covered
the case where "-canary" is used as
suffix (https://travis-ci.org/kubernetes-csi/external-attacher/builds/484095261).

/assign @msau42 