### PR TITLE
verify-subtree.sh: relax check and ignore old content

### DIFF
--- a/verify-subtree.sh
+++ b/verify-subtree.sh
@@ -30,7 +30,7 @@ if [ ! "$DIR" ]; then
     exit 1
 fi
 
-REV=$(git log -n1 --format=format:%H --no-merges -- "$DIR")
+REV=$(git log -n1 --remove-empty --format=format:%H --no-merges -- "$DIR")
 if [ "$REV" ]; then
     echo "Directory '$DIR' contains non-upstream changes:"
     echo


### PR DESCRIPTION
If for whatever reasons a repo already had a `release-tools` directory
before doing a clean import of it with `git subtree`, the check used
to fail because it found those old commits.

This can be fixed by telling `git log` to stop when the directory
disappears from the repo. There has to be a commit with removes the
old content, because otherwise `git subtree add` doesn't work.

Fixes: https://github.com/kubernetes-csi/external-resizer/issues/21