### PR TITLE
build.make: avoid unit-testing E2E test suite

### DIFF
--- a/build.make
+++ b/build.make
@@ -98,7 +98,7 @@ test:
 test: test-go
 test-go:
 	@ echo; echo "### $@:"
-	go test `go list ./... | grep -v 'vendor' $(TEST_GO_FILTER_CMD)` $(TESTARGS)
+	go test `go list ./... | grep -v -e 'vendor' -e '/test/e2e$$' $(TEST_GO_FILTER_CMD)` $(TESTARGS)
 
 .PHONY: test-vet
 test: test-vet


### PR DESCRIPTION
In repos that have a test/e2e, that test suite should be run
separately because it depends on a running cluster.