### PR TITLE
prow.sh: remove AllAlpha=all, part II

### DIFF
--- a/prow.sh
+++ b/prow.sh
@@ -268,8 +268,9 @@ configvar CSI_PROW_E2E_ALPHA "$(get_versioned_variable CSI_PROW_E2E_ALPHA "${csi
 # it anymore for older releases.
 configvar CSI_PROW_E2E_ALPHA_GATES_1_13 'VolumeSnapshotDataSource=true,BlockVolume=true,CSIBlockVolume=true' "alpha feature gates for Kubernetes 1.13"
 configvar CSI_PROW_E2E_ALPHA_GATES_1_14 'VolumeSnapshotDataSource=true,ExpandCSIVolumes=true' "alpha feature gates for Kubernetes 1.14"
-# TODO: add new CSI_PROW_ALPHA_GATES entry for future Kubernetes releases
-configvar CSI_PROW_E2E_ALPHA_GATES_LATEST 'AllAlpha=true,ExpandCSIVolumes=true' "alpha feature gates for latest Kubernetes"
+# TODO: add new CSI_PROW_ALPHA_GATES_xxx entry for future Kubernetes releases and
+# add new gates to CSI_PROW_E2E_ALPHA_GATES_LATEST.
+configvar CSI_PROW_E2E_ALPHA_GATES_LATEST 'VolumeSnapshotDataSource=true,ExpandCSIVolumes=true' "alpha feature gates for latest Kubernetes"
 configvar CSI_PROW_E2E_ALPHA_GATES "$(get_versioned_variable CSI_PROW_E2E_ALPHA_GATES "${csi_prow_kubernetes_version_suffix}")" "alpha E2E feature gates"
 
 # Some tests are known to be unusable in a KinD cluster. For example,


### PR DESCRIPTION
This was already meant to be done earlier in cda2fc5874b42ed68b.
While at it, extend the permanent TODO with guidance on future feature
gates.