### PR TITLE
build.make: Replace 'return' to 'exit' to fix shellcheck error

### DIFF
--- a/build.make
+++ b/build.make
@@ -143,11 +143,11 @@ test-shellcheck:
 	@ ret=0; \
 	if ! command -v docker; then \
 		echo "skipped, no Docker"; \
-		return 0; \
+		exit 0; \
         fi; \
 	for dir in $(abspath $(TEST_SHELLCHECK_DIRS)); do \
 		echo; \
 		echo "$$dir:"; \
 		./release-tools/verify-shellcheck.sh "$$dir" || ret=1; \
 	done; \
-	return $$ret
+	exit $$ret


### PR DESCRIPTION
I've got following error message while executed the `make test` command:

> Using shellcheck 0.6.0 docker image.
> Congratulations! All shell files are passing lint.
> /bin/sh: line 0: return: can only `return' from a function or sourced script
> make: *** [test-shellcheck] Error 1

The root cause is the test-shellcheck section in the build.make file should use `exit` command to return status code, instead of using `return`.