### PR TITLE
update to Go 1.12.4

### DIFF
--- a/travis.yml
+++ b/travis.yml
@@ -4,7 +4,7 @@ services:
   - docker
 matrix:
   include:
-  - go: 1.11.1
+  - go: 1.12.4
 before_script:
 - mkdir -p bin
 - wget https://github.com/golang/dep/releases/download/v0.5.1/dep-linux-amd64 -O bin/dep


### PR DESCRIPTION
Kubernetes also requires 1.12. We pick the latest stable release
for CI builds.