### PR TITLE
prow.sh: tag master images with a large version number

### DIFF
--- a/prow.sh
+++ b/prow.sh
@@ -485,7 +485,7 @@ start_cluster () {
                     tag="$(echo "${CSI_PROW_KUBERNETES_VERSION}" | sed -e 's/release-\(.*\)/v\1.0-release./')";;
                 *)
                     # We have to make something up. v1.0.0 did not work for some reasons.
-                    tag="v1.14.0-";;
+                    tag="v999.999.999-";;
             esac
             tag="$tag$(cd "$GOPATH/src/k8s.io/kubernetes" && git rev-list --abbrev-commit HEAD).csiprow"
             (cd "$GOPATH/src/k8s.io/kubernetes" && run git tag -f "$tag") || die "git tag failed"


### PR DESCRIPTION
kind [checks kubernetes tagged versions](https://github.com/kubernetes-sigs/kind/blob/9205bac4a8377fb7d301a8c14650592b85a34f58/pkg/cluster/internal/kubeadm/config.go#L451-L459) to figure out which config to use. For master builds, tag a large version so that kind will look for the latest config versions.

Tested master alpha clusters in https://github.com/kubernetes-csi/csi-driver-host-path/pull/74

```release-notes
Tag master binaries with v999.999.999 so that kind will use the latest kubeadm config
```