### PR TITLE
Fix CI jobs on Kubernetes master

### DIFF
--- a/prow.sh
+++ b/prow.sh
@@ -101,7 +101,7 @@ configvar CSI_PROW_GO_VERSION_GINKGO "${CSI_PROW_GO_VERSION_BUILD}" "Go version 
 # kind version to use. If the pre-installed version is different,
 # the desired version is downloaded from https://github.com/kubernetes-sigs/kind/releases/download/
 # (if available), otherwise it is built from source.
-configvar CSI_PROW_KIND_VERSION v0.4.0 "kind"
+configvar CSI_PROW_KIND_VERSION 2555d8e09d5a77ee718414cec9f6083dfa028dc5 "kind"
 
 # ginkgo test runner version to use. If the pre-installed version is
 # different, the desired version is built from source.
@@ -322,7 +322,7 @@ configvar CSI_PROW_E2E_ALPHA_GATES "$(get_versioned_variable CSI_PROW_E2E_ALPHA_
 # whether they can run with the current cluster provider, but until
 # they are, we filter them out by name. Like the other test selection
 # variables, this is again a space separated list of regular expressions.
-configvar CSI_PROW_E2E_SKIP 'while.kubelet.is.down.*Disruptive' "tests that need to be skipped"
+configvar CSI_PROW_E2E_SKIP 'Disruptive' "tests that need to be skipped"
 
 # This is the directory for additional result files. Usually set by Prow, but
 # if not (for example, when invoking manually) it defaults to the work directory.
@@ -379,8 +379,8 @@ install_kind () {
     if run curl --fail --location -o "${CSI_PROW_WORK}/bin/kind" "https://github.com/kubernetes-sigs/kind/releases/download/${CSI_PROW_KIND_VERSION}/kind-linux-amd64"; then
         chmod u+x "${CSI_PROW_WORK}/bin/kind"
     else
-        git_checkout https://github.com/kubernetes-sigs/kind "$GOPATH/src/sigs.k8s.io/kind" "${CSI_PROW_KIND_VERSION}" --depth=1 &&
-        run_with_go "${CSI_PROW_GO_VERSION_KIND}" go build -o "${CSI_PROW_WORK}/bin/kind" sigs.k8s.io/kind
+        git_checkout https://github.com/kubernetes-sigs/kind "${GOPATH}/src/sigs.k8s.io/kind" "${CSI_PROW_KIND_VERSION}" --depth=1 &&
+        (cd "${GOPATH}/src/sigs.k8s.io/kind" && make install INSTALL_DIR="${CSI_PROW_WORK}/bin")
     fi
 }
 
@@ -422,6 +422,27 @@ git_checkout () {
         (cd "$path" && run git fetch "$repo" '+refs/heads/*:refs/remotes/csiprow/heads/*' '+refs/tags/*:refs/tags/*') || die "fetching $repo failed"
         (cd "$path" && run git checkout "$revision") || die "checking out $repo $revision failed"
     fi
+    # This is useful for local testing or when switching between different revisions in the same
+    # repo.
+    (cd "$path" && run git clean -fdx) || die "failed to clean $path"
+}
+
+# This clones a repo ("https://github.com/kubernetes/kubernetes")
+# in a certain location ("$GOPATH/src/k8s.io/kubernetes") at
+# a the head of a specific branch (i.e., release-1.13, master).
+# The directory cannot exist.
+git_clone_branch () {
+    local repo path branch parent
+    repo="$1"
+    shift
+    path="$1"
+    shift
+    branch="$1"
+    shift
+
+    parent="$(dirname "$path")"
+    mkdir -p "$parent"
+    (cd "$parent" && run git clone --single-branch --branch "$branch" "$repo" "$path") || die "cloning $repo" failed
     # This is useful for local testing or when switching between different revisions in the same
     # repo.
     (cd "$path" && run git clean -fdx) || die "failed to clean $path"
@@ -472,25 +493,10 @@ start_cluster () {
             if [ "$version" = "latest" ]; then
                 version=master
             fi
-            git_checkout https://github.com/kubernetes/kubernetes "$GOPATH/src/k8s.io/kubernetes" "$version" --depth=1 || die "checking out Kubernetes $version failed"
+            git_clone_branch https://github.com/kubernetes/kubernetes "${CSI_PROW_WORK}/src/kubernetes" "$version" || die "checking out Kubernetes $version failed"
 
-            # "kind build" and/or the Kubernetes build rules need at least one tag, which we don't have
-            # when doing a shallow fetch. Therefore we fake one:
-            # release-1.12 -> v1.12.0-release.<rev>.csiprow
-            # latest or <revision> -> v1.14.0-<rev>.csiprow
-            case "${CSI_PROW_KUBERNETES_VERSION}" in
-                release-*)
-                    # Ignore: See if you can use ${variable//search/replace} instead.
-                    # shellcheck disable=SC2001
-                    tag="$(echo "${CSI_PROW_KUBERNETES_VERSION}" | sed -e 's/release-\(.*\)/v\1.0-release./')";;
-                *)
-                    # We have to make something up. v1.0.0 did not work for some reasons.
-                    tag="v999.999.999-";;
-            esac
-            tag="$tag$(cd "$GOPATH/src/k8s.io/kubernetes" && git rev-list --abbrev-commit HEAD).csiprow"
-            (cd "$GOPATH/src/k8s.io/kubernetes" && run git tag -f "$tag") || die "git tag failed"
-            go_version="$(go_version_for_kubernetes "$GOPATH/src/k8s.io/kubernetes" "$version")" || die "cannot proceed without knowing Go version for Kubernetes"
-            run_with_go "$go_version" kind build node-image --type bazel --image csiprow/node:latest --kube-root "$GOPATH/src/k8s.io/kubernetes" || die "'kind build node-image' failed"
+            go_version="$(go_version_for_kubernetes "${CSI_PROW_WORK}/src/kubernetes" "$version")" || die "cannot proceed without knowing Go version for Kubernetes"
+            run_with_go "$go_version" kind build node-image --type bazel --image csiprow/node:latest --kube-root "${CSI_PROW_WORK}/src/kubernetes" || die "'kind build node-image' failed"
             csi_prow_kind_have_kubernetes=true
         fi
         image="csiprow/node:latest"


### PR DESCRIPTION
Kubernetes master changed the way that versions are determined, which requires a new kind build.

This PR has 3 changes:
1. Use a master commit of kind that includes the fix for Kubernetes
master.
2. Use git clone instead of git checkout (shallow) to source Kubernetes.
This lets kind correctly figure out the Kubernetes release tag.
3. Build kind with make install. The kind fix was not working correctly
when built with go build.

This has been tested in https://github.com/kubernetes-csi/csi-driver-host-path/pull/77