### PR TITLE
Add rule for building Windows binaries

### DIFF
--- a/build.make
+++ b/build.make
@@ -63,6 +63,7 @@ endif
 build-%:
 	mkdir -p bin
 	CGO_ENABLED=0 GOOS=linux go build -a -ldflags '-X main.version=$(REV) -extldflags "-static"' -o ./bin/$* ./cmd/$*
+	CGO_ENABLED=0 GOOS=windows go build -a -ldflags '-X main.version=$(REV) -extldflags "-static"' -o ./bin/$* ./cmd/$*
 
 container-%: build-%
 	docker build -t $*:latest -f $(shell if [ -e ./cmd/$*/Dockerfile ]; then echo ./cmd/$*/Dockerfile; else echo Dockerfile; fi) --label revision=$(REV) .


### PR DESCRIPTION
Add a rule for building Windows versions of binaries. We can build Windows binaries using golang  from Linux based build machines. This is needed for node components like the node driver registrar to support Windows nodes in Kubernetes.