### PR TITLE
Create 2-node kind cluster since topology support is added to hostpath

### DIFF
--- a/prow.sh
+++ b/prow.sh
@@ -521,6 +521,7 @@ kind: Cluster
 apiVersion: kind.sigs.k8s.io/v1alpha3
 nodes:
 - role: control-plane
+- role: worker
 EOF
 
     # kubeadm has API dependencies between apiVersion and Kubernetes version


### PR DESCRIPTION
Create 2-node kind cluster since topology support is added to hostpath

Tested with https://github.com/kubernetes-csi/csi-driver-host-path/pull/92

Fixes #28

/release-notes-none

cc @msau42 