### PR TITLE
Build Windows only for amd64

### DIFF
--- a/build.make
+++ b/build.make
@@ -57,13 +57,17 @@ else
 TESTARGS =
 endif
 
+ARCH := $(if $(GOARCH),$(GOARCH),$(shell go env GOARCH))
+
 # Specific packages can be excluded from each of the tests below by setting the *_FILTER_CMD variables
 # to something like "| grep -v 'github.com/kubernetes-csi/project/pkg/foobar'". See usage below.
 
 build-%:
 	mkdir -p bin
 	CGO_ENABLED=0 GOOS=linux go build -a -ldflags '-X main.version=$(REV) -extldflags "-static"' -o ./bin/$* ./cmd/$*
-	CGO_ENABLED=0 GOOS=windows go build -a -ldflags '-X main.version=$(REV) -extldflags "-static"' -o ./bin/$*.exe ./cmd/$*
+	if [ "$$ARCH" = "amd64" ]; then \
+		CGO_ENABLED=0 GOOS=windows go build -a -ldflags '-X main.version=$(REV) -extldflags "-static"' -o ./bin/$*.exe ./cmd/$* ; \
+	fi
 
 container-%: build-%
 	docker build -t $*:latest -f $(shell if [ -e ./cmd/$*/Dockerfile ]; then echo ./cmd/$*/Dockerfile; else echo Dockerfile; fi) --label revision=$(REV) .


### PR DESCRIPTION
Skip with trying to build CSI binaries for Windows OS in non amd64 arch. Addresses https://github.com/kubernetes-csi/external-attacher/issues/185#issuecomment-538949667

This is just a short term fix. I think long term we should specify a matrix of supported OS/ARCH combos as is done in [k/k](https://github.com/kubernetes/kubernetes/blob/886af6aa26fd82d495931129863cd98ac21ea90e/build/root/.bazelrc#L33-L46)