### PR TITLE
Run travis builds for ppc64le

### DIFF
--- a/travis.yml
+++ b/travis.yml
@@ -1,15 +1,16 @@
 language: go
 sudo: required
+arch:
+  - amd64
+  - ppc64le
 services:
   - docker
 git:
   depth: false
-matrix:
-  include:
-  - go: 1.13.3
+go: 1.13.3
 before_script:
 - mkdir -p bin
-- wget https://github.com/golang/dep/releases/download/v0.5.1/dep-linux-amd64 -O bin/dep
+- wget https://github.com/golang/dep/releases/download/v0.5.1/dep-linux-$(go env GOARCH) -O bin/dep
 - chmod u+x bin/dep
 - export PATH=$PWD/bin:$PATH
 script:


### PR DESCRIPTION
This is in ref to #48 and an extension to the PR: #47. This PR allows the travis build to run for ppc64le env as well. Here are the changes done:

1) Add image name based on arch. For amd64 image names remains same, for ppc64le, add -ppc64le to the image name.
2) Add arch variable in travis.yaml to run the build on both amd64 and ppc64le archs and make go version same for all builds.
3) Disable shellcheck for ppc64le, as shellcheck is not available for the arch yet. (A issue has been opened: https://github.com/koalaman/shellcheck/issues/1767)
3) Download the correct dep binary for the given arch.
