### PR TITLE
prow.sh: also configure feature gates for kubelet

### DIFF
--- a/prow.sh
+++ b/prow.sh
@@ -569,6 +569,13 @@ kubeadmConfigPatches:
     kubeletExtraArgs:
       "feature-gates": "$gates"
 - |
+  apiVersion: kubelet.config.k8s.io/v1beta1
+  kind: KubeletConfiguration
+  metadata:
+    name: config
+  featureGates:
+$(list_gates "$gates")
+- |
   apiVersion: kubeproxy.config.k8s.io/v1alpha1
   kind: KubeProxyConfiguration
   metadata:


### PR DESCRIPTION
That this hasn't been done before is an oversight. Apparently it
hasn't been a problem because there never have been feature gates that
mattered?

/release-note-none
