### PR TITLE
Change 'make test-vet' back to call 'go vet'

### DIFF
--- a/build.make
+++ b/build.make
@@ -113,7 +113,7 @@ test-go:
 test: test-vet
 test-vet:
 	@ echo; echo "### $@:"
-	go test $(GOFLAGS_VENDOR) `go list $(GOFLAGS_VENDOR) ./... | grep -v vendor $(TEST_VET_FILTER_CMD)`
+	go vet $(GOFLAGS_VENDOR) `go list $(GOFLAGS_VENDOR) ./... | grep -v vendor $(TEST_VET_FILTER_CMD)`
 
 .PHONY: test-fmt
 test: test-fmt


### PR DESCRIPTION
It feels to me like `make test-vet` was supposed to call `go vet` and not `go test` because that is already done in `make test-go` (extra excluding e2e directory, but still very similar).

Not sure if it was intentional or by accident in https://github.com/kubernetes-csi/csi-release-tools/pull/42

ptal: @pohly @msau42 