### PR TITLE
update release tools instructions

### DIFF
--- a/SIDECAR_RELEASE_PROCESS.md
+++ b/SIDECAR_RELEASE_PROCESS.md
@@ -54,14 +54,21 @@ naming convention `<hostpath-deployment-version>-on-<kubernetes-version>`.
   generator](https://github.com/kubernetes/release/tree/master/cmd/release-notes)
 1. Generate release notes for the release. Replace arguments with the relevant
   information.
-    ```
-    GITHUB_TOKEN=<token> ./release-notes --start-sha=0ed6978fd199e3ca10326b82b4b8b8e916211c9b --end-sha=3cb3d2f18ed8cb40371c6d8886edcabd1f27e7b9 \
-    --github-org=kubernetes-csi --github-repo=external-attacher -branch=master -output out.md
-    ```
-    * `--start-sha` should point to the last release from the same branch. For
-    example:
-        * `1.X-1.0` tag when releasing `1.X.0`
-        * `1.X.Y-1` tag when releasing `1.X.Y`
+    * For new minor releases on master:
+        ```
+        GITHUB_TOKEN=<token> release-notes --discover=mergebase-to-latest
+        --github-org=kubernetes-csi --github-repo=external-provisioner
+        --required-author="" --output out.md
+        ```
+    * For new patch releases on a release branch:
+        ```
+        GITHUB_TOKEN=<token> release-notes --branch=release-1.1
+        --start-rev=v1.1.1 --end-sha=f0a9219b29cc9053047c39d149ce9b22bc7b918b
+        --github-org=kubernetes-csi --github-repo=external-provisioner
+        --required-author="" --output out.md
+        ```
+        * `--start-rev` should point to the last patch release from the release branch.
+        * `--end-sha` should point to the latest commit from the release branch.
 1. Compare the generated output to the new commits for the release to check if
    any notable change missed a release note.
 1. Reword release notes as needed. Make sure to check notes for breaking


### PR DESCRIPTION
I updated to the latest release tools. There are some new options that help reduce the toil of finding the right commit hashes. The new "patch-to-patch" discover mode doesn't work for our patch release model, but I may spend some time trying to add one that works for us.

Here's a sample release notes format that gets generated. We'll still need to do some post modifications to the title and documentation link, but the rest seems ok.
```
# Release notes for 

[Documentation](https://docs.k8s.io/docs/home)

# Changelog since v1.1.1

## Changes by Kind

### Feature
 - Users can now provide a secret name and namespace during provision by passing the correct storage class parameters: "provisioner-secret-name" and "provisioner-secret-namespace" ([#286](https://github.com/kubernetes-csi/external-provisioner/pull/286), [@oleksiys](https://github.com/oleksiys))
### Other (Bug, Cleanup or Flake)
 - A new flag --leader-election-namespace is introduced to allow the user to set where the leader election lock resource lives. ([#298](https://github.com/kubernetes-csi/external-provisioner/pull/298), [@verult](https://github.com/verult)) - Handle deletion of CSI migrated volumes ([#276](https://github.com/kubernetes-csi/external-provisioner/pull/276), [@ddebroy](https://github.com/ddebroy))
```