### PR TITLE
Skip prow job when on Kubernetes v1.16.

### DIFF
--- a/prow.sh
+++ b/prow.sh
@@ -1022,6 +1022,28 @@ function version_gt() {
 }
 
 main () {
+    # This check assumes that the current configuration uses a driver deployment
+    # which has been updated to use v1 APIs that aren't available in Kubernetes < 1.17.
+    # The check can be removed when all Prow jobs for Kubernetes < 1.17 are removed.
+    if ! ( version_gt "${CSI_PROW_KUBERNETES_VERSION}" "1.16.255" || "${CSI_PROW_KUBERNETES_VERSION}" == "latest" ); then
+	filtered_tests=
+	skipped_tests=
+	for test in ${CSI_PROW_TESTS}; do
+	    case "$test" in
+            parallel|parallel|serial|parallel-alpha|serial-alpha):
+			skipped_tests="$skipped_tests $test"
+		        ;;
+		*)
+			filtered_tests="$filterered_tests $test"
+			;;
+	    esac
+	done
+	if [ "$skipped_tests" ]; then
+	   info "Testing on Kubernetes ${CSI_PROW_KUBERNETES_VERSION} is no longer supported. Skipping CSI_PROW_TESTS $skipped_tests."
+	   CSI_PROW_TESTS="$filtered_tests"
+	fi
+    fi
+
     local images ret
     ret=0
 


### PR DESCRIPTION
Going forward we are using the GA version of the CSINode object in the sidecars. However, Kubernetes v1.16 only contains the v1beta1 version of that object, hence we need to skip the prow job in this version.

/assign @pohly @msau42 