### PR TITLE
cloud build: bump timeout in Prow job

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -16,7 +16,7 @@
 # To promote release images, see https://github.com/kubernetes/k8s.io/tree/master/k8s.gcr.io/images/k8s-staging-sig-storage.
 
 # This must be specified in seconds. If omitted, defaults to 600s (10 mins).
-timeout: 1200s
+timeout: 1800s
 # This prevents errors if you don't use both _GIT_TAG and _PULL_BASE_REF,
 # or any new substitutions added in the future.
 options:


### PR DESCRIPTION
The recent [post-external-snapshotter-push-images](post-external-snapshotter-push-images) builds have been failing due to [timeout](https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/post-external-snapshotter-push-images/1280665205386252288). 

Snippet from log:
```
go: finding github.com/prometheus/common v0.4.1
go: finding github.com/matttproud/golang_protobuf_extensions v1.0.1
+ CGO_ENABLED=0 GOOS=windows GOARCH=amd64 go build -a -ldflags '-X main.version=v2.1.0-57-g097b1fc7 -extldflags "-static"' -o ./bin/csi-snapshotter.exe ./cmd/csi-snapshotter
+ CGO_ENABLED=0 GOOS=linux GOARCH=ppc64le go build -a -ldflags '-X main.version=v2.1.0-57-g097b1fc7 -extldflags "-static"' -o ./bin/csi-snapshotter-ppc64le ./cmd/csi-snapshotter
+ CGO_ENABLED=0 GOOS=linux GOARCH=s390x go build -a -ldflags '-X main.version=v2.1.0-57-g097b1fc7 -extldflags "-static"' -o ./bin/csi-snapshotter-s390x ./cmd/csi-snapshotter
TIMEOUT
ERROR: context deadline exceeded
```

Since the build was close to completion, increasing the timeout by 10 mins should suffice. 