### PR TITLE
prow.sh: only run alpha tests for latest Kubernetes release

### DIFF
--- a/prow.sh
+++ b/prow.sh
@@ -248,11 +248,16 @@ configvar CSI_PROW_DEP_VERSION v0.5.1 "golang dep version to be used for vendor 
 #
 # Unknown or unsupported entries are ignored.
 #
+# Testing of alpha features is only supported for CSI_PROW_KUBERNETES_VERSION=latest
+# because CSI_PROW_E2E_ALPHA and CSI_PROW_E2E_ALPHA_GATES are not set for
+# older Kubernetes releases. The script supports that, it just isn't done because
+# it is not needed and would cause additional maintenance effort.
+#
 # Sanity testing with csi-sanity only covers the CSI driver itself and
 # thus only makes sense in repos which provide their own CSI
 # driver. Repos can enable sanity testing by setting
 # CSI_PROW_TESTS_SANITY=sanity.
-configvar CSI_PROW_TESTS "unit parallel serial parallel-alpha serial-alpha sanity" "tests to run"
+configvar CSI_PROW_TESTS "unit parallel serial $(if [ "${CSI_PROW_KUBERNETES_VERSION}" = "latest" ]; then echo parallel-alpha serial-alpha; fi) sanity" "tests to run"
 tests_enabled () {
     local t1 t2
     # We want word-splitting here, so ignore: Quote to prevent word splitting, or split robustly with mapfile or read -a.


### PR DESCRIPTION
Commit 7bcee13d79012 added alpha feature gates for Kubernetes 1.19 in
the CSI_PROW_E2E_ALPHA_GATES_LATEST variable based on the comment in
https://github.com/kubernetes-csi/external-provisioner/pull/493#discussion_r502663402
that alpha testing only runs for the latest Kubernetes.

But some components (like external-health-monitor) are configured with
a single Prow job which runs the default set of tests on a stable
Kubernetes release (currently 1.17). Those tests used to include alpha
testing which then broke during Kind cluster startup because the
Kubernetes 1.19 feature gates weren't recognized by 1.17.

The solution is to disable alpha testing for Kubernetes != latest in
the default set of tests.