### PR TITLE
upgrade csi-test to v4.0.2

### DIFF
--- a/prow.sh
+++ b/prow.sh
@@ -227,7 +227,7 @@ configvar CSI_PROW_E2E_IMPORT_PATH "k8s.io/kubernetes" "E2E package"
 # of the cluster. The alternative would have been to (cross-)compile csi-sanity
 # and install it inside the cluster, which is not necessarily easier.
 configvar CSI_PROW_SANITY_REPO https://github.com/kubernetes-csi/csi-test "csi-test repo"
-configvar CSI_PROW_SANITY_VERSION 5421d9f3c37be3b95b241b44a094a3db11bee789 "csi-test version" # latest master
+configvar CSI_PROW_SANITY_VERSION af2d21f66c88d7b4956c17d8123cdc563ca0ba0a "csi-test version" # latest master
 configvar CSI_PROW_SANITY_IMPORT_PATH github.com/kubernetes-csi/csi-test "csi-test package"
 configvar CSI_PROW_SANITY_SERVICE "hostpath-service" "Kubernetes TCP service name that exposes csi.sock"
 configvar CSI_PROW_SANITY_POD "csi-hostpathplugin-0" "Kubernetes pod with CSI driver"

--- a/prow.sh
+++ b/prow.sh
@@ -227,7 +227,7 @@ configvar CSI_PROW_E2E_IMPORT_PATH "k8s.io/kubernetes" "E2E package"
 # of the cluster. The alternative would have been to (cross-)compile csi-sanity
 # and install it inside the cluster, which is not necessarily easier.
 configvar CSI_PROW_SANITY_REPO https://github.com/kubernetes-csi/csi-test "csi-test repo"
-configvar CSI_PROW_SANITY_VERSION af2d21f66c88d7b4956c17d8123cdc563ca0ba0a "csi-test version" # latest master
+configvar CSI_PROW_SANITY_VERSION v4.0.2 "csi-test version" # v4.0.2
 configvar CSI_PROW_SANITY_IMPORT_PATH github.com/kubernetes-csi/csi-test/v4 "csi-test package"
 configvar CSI_PROW_SANITY_SERVICE "hostpath-service" "Kubernetes TCP service name that exposes csi.sock"
 configvar CSI_PROW_SANITY_POD "csi-hostpathplugin-0" "Kubernetes pod with CSI driver"

--- a/prow.sh
+++ b/prow.sh
@@ -228,7 +228,7 @@ configvar CSI_PROW_E2E_IMPORT_PATH "k8s.io/kubernetes" "E2E package"
 # and install it inside the cluster, which is not necessarily easier.
 configvar CSI_PROW_SANITY_REPO https://github.com/kubernetes-csi/csi-test "csi-test repo"
 configvar CSI_PROW_SANITY_VERSION af2d21f66c88d7b4956c17d8123cdc563ca0ba0a "csi-test version" # latest master
-configvar CSI_PROW_SANITY_IMPORT_PATH github.com/kubernetes-csi/csi-test "csi-test package"
+configvar CSI_PROW_SANITY_IMPORT_PATH github.com/kubernetes-csi/csi-test/v4 "csi-test package"
 configvar CSI_PROW_SANITY_SERVICE "hostpath-service" "Kubernetes TCP service name that exposes csi.sock"
 configvar CSI_PROW_SANITY_POD "csi-hostpathplugin-0" "Kubernetes pod with CSI driver"
 configvar CSI_PROW_SANITY_CONTAINER "hostpath" "Kubernetes container with CSI driver"


### PR DESCRIPTION
### Reason

The current csi-test version doesn't support the new capabilities, like VOLUME_CONDITION and GET_VOLUME. Both of them are needed by the external-health-monitor project and other projects which are integrating with external-health-monitor: https://github.com/kubernetes-csi/csi-driver-host-path/pull/210.

In that case, I think we need to upgrade the version of csi-test

```release-note
upgrade version of csi-test to v4.0.2
```