### PR TITLE
cloud build: double the timeout, now 1 hour

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -16,7 +16,9 @@
 # To promote release images, see https://github.com/kubernetes/k8s.io/tree/master/k8s.gcr.io/images/k8s-staging-sig-storage.
 
 # This must be specified in seconds. If omitted, defaults to 600s (10 mins).
-timeout: 1800s
+# Building three images in external-snapshotter takes roughly half an hour,
+# sometimes more.
+timeout: 3600s
 # This prevents errors if you don't use both _GIT_TAG and _PULL_BASE_REF,
 # or any new substitutions added in the future.
 options:


### PR DESCRIPTION
Builds of external-snapshotter sometimes timed out because it builds
three images and that takes almost half an hour (the previous limit)
and more if the network is slow.

There's no good way to set timeouts per repo and a too high timeout
for shouldn't cause any issue, therefore the timeout gets increased
everywhere.

/cc @xing-yang 