### PR TITLE
Make the spelling and boilerplate checks optional

### DIFF
--- a/build.make
+++ b/build.make
@@ -278,15 +278,13 @@ check-go-version-%:
 
 # Test for spelling errors.
 .PHONY: test-spelling
-test: test-spelling
 test-spelling:
 	@ echo; echo "### $@:"
-	@ ./release-tools/verify-spelling.sh
+	@ ./release-tools/verify-spelling.sh "$(pwd)"
 
 # Test the boilerplates of the files.
 .PHONY: test-boilerplate
-test: test-boilerplate
 test-boilerplate:
 	@ echo; echo "### $@:"
-	@ ./release-tools/verify-boilerplate.sh
+	@ ./release-tools/verify-boilerplate.sh "$(pwd)"
 

--- a/verify-boilerplate.sh
+++ b/verify-boilerplate.sh
@@ -25,8 +25,8 @@ if [[ -z "$(command -v python)" ]]; then
   update-alternatives --install /usr/bin/python python /usr/bin/python3 1
 fi
 
-# The csi-release-tools directory.
-TOOLS="$(dirname "${BASH_SOURCE[0]}")"
+# The csi-release-tools directory (absolute path).
+TOOLS="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
 
 # Directory to check. Default is the parent of the tools themselves.
 ROOT="${1:-${TOOLS}/..}"

--- a/verify-spelling.sh
+++ b/verify-spelling.sh
@@ -20,8 +20,8 @@ set -o pipefail
 
 TOOL_VERSION="v0.3.4"
 
-# The csi-release-tools directory.
-TOOLS="$(dirname "${BASH_SOURCE[0]}")"
+# The csi-release-tools directory (absolute path).
+TOOLS="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
 
 # Directory to check. Default is the parent of the tools themselves.
 ROOT="${1:-${TOOLS}/..}"


### PR DESCRIPTION
The boilerplate and spelling tests are made optional and the default paths in the relative scripts are made absolute.

This is in response to the discussion [here](https://github.com/kubernetes-csi/csi-driver-nfs/pull/133#discussion_r556036984) for the PR ![#133](https://github.com/kubernetes-csi/csi-driver-nfs/pull/133)