### PR TITLE
verify-boilerplate.sh: fix path to script

### DIFF
--- a/verify-boilerplate.sh
+++ b/verify-boilerplate.sh
@@ -31,8 +31,7 @@ TOOLS="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
 # Directory to check. Default is the parent of the tools themselves.
 ROOT="${1:-${TOOLS}/..}"
 
-boilerDir="${ROOT}/boilerplate"
-boiler="${boilerDir}/boilerplate.py"
+boiler="${TOOLS}/boilerplate/boilerplate.py"
 
 mapfile -t files_need_boilerplate < <("${boiler}" --rootdir="${ROOT}" --verbose)
 


### PR DESCRIPTION
The previous path was wrong because it was relative to the directory
being checked, not the release-tools directory:

```
csi-driver-host-path$ ./release-tools/verify-boilerplate.sh
Verifying boilerplate
./release-tools/verify-boilerplate.sh: line 37: /nvme/gopath/src/github.com/kubernetes-csi/csi-driver-host-path/boilerplate/boilerplate.py: No such file or directory
```