### PR TITLE
prow.sh: fix "on-master" prow jobs

### DIFF
--- a/prow.sh
+++ b/prow.sh
@@ -71,7 +71,7 @@ version_to_git () {
     version="$1"
     shift
     case "$version" in
-        latest) echo "master";;
+        latest|master) echo "master";;
         release-*) echo "$version";;
         *) echo "v$version";;
     esac


### PR DESCRIPTION
The recent introduction of version_to_git broke Prow jobs with
CSI_PROW_KUBERNETES_VERSION=latest because that version was first
converted to "master" and then once more to "vmaster". The second call
must be idempotent because "master" is already a branch name.