### PR TITLE
add build-arg ARCH

### DIFF
--- a/build.make
+++ b/build.make
@@ -149,6 +149,7 @@ $(CMDS:%=push-multiarch-%): push-multiarch-%: check-pull-base-ref build-%
 				--platform=$$os/$$arch \
 				--file $$(eval echo \$${dockerfile_$$os}) \
 				--build-arg binary=./bin/$*$$suffix \
+				--build-arg ARCH=$$arch \
 				--label revision=$(REV) \
 				.; \
 		done; \


### PR DESCRIPTION
this PR is for https://github.com/kubernetes-csi/csi-driver-nfs/pull/166 to build multi-arch images
original error:
```
#7 [3/3] RUN apt update && apt install ca-certificates mount nfs-common nfs...
#7 0.115 /bin/sh: Invalid ELF image for this architecture
#7 ERROR: executor failed running [/dev/.buildkit_qemu_emulator /bin/sh -c apt update && apt install ca-certificates mount nfs-common nfs-kernel-server -y || true]: exit code: 255
```

https://prow.k8s.io/view/gcs/kubernetes-jenkins/logs/post-csi-driver-nfs-push-images/1363278699297771520

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
none
```