### PR TITLE
verify-go-version.sh: fix check after removal of travis.yml

### DIFF
--- a/verify-go-version.sh
+++ b/verify-go-version.sh
@@ -31,7 +31,7 @@ version=$("$GO" version) || die "determining version of $GO failed"
 majorminor=$(echo "$version" | sed -e 's/.*go\([0-9]*\)\.\([0-9]*\).*/\1.\2/')
 # SC1091: Not following: release-tools/prow.sh was not specified as input (see shellcheck -x).
 # shellcheck disable=SC1091
-expected=$(. release-tools/prow.sh && echo "$$CSI_PROW_GO_VERSION_BUILD")
+expected=$(. release-tools/prow.sh >/dev/null && echo "$CSI_PROW_GO_VERSION_BUILD")
 
 if [ "$majorminor" != "$expected" ]; then
     cat >&2 <<EOF


### PR DESCRIPTION
Two problems:
- sourcing prow.sh prints info messages about settings which should
  better be suppressed
- the expected value was hidden by the incorrect make-style quoting
  of CSI_PROW_GO_VERSION_BUILD