### PR TITLE
Mock testing

### DIFF
--- a/prow.sh
+++ b/prow.sh
@@ -354,11 +354,7 @@ configvar CSI_SNAPSHOTTER_VERSION "$(default_csi_snapshotter_version)" "external
 # whether they can run with the current cluster provider, but until
 # they are, we filter them out by name. Like the other test selection
 # variables, this is again a space separated list of regular expressions.
-#
-# "different node" test skips can be removed once
-# https://github.com/kubernetes/kubernetes/pull/82678 has been backported
-# to all the K8s versions we test against
-configvar CSI_PROW_E2E_SKIP 'Disruptive|different\s+node' "tests that need to be skipped"
+configvar CSI_PROW_E2E_SKIP 'Disruptive' "tests that need to be skipped"
 
 # This creates directories that are required for testing.
 ensure_paths () {


### PR DESCRIPTION
We already run the e2e.test binary from Kubernetes in different
invocations (serial, parallel, with and without alpha
features). Enabling also the in-tree mock tests is therefore easy and
makes sense in particular for our canary jobs where we try out how our
canary images work in existing deployments before updating those
deployments.

To role this out:
- merge this PR
- update csi-driver-host-path

We don't need to update jobs because the default is to include mock tests when
canary images are enabled.
