### PR TITLE
Explicitly reference PULL_BASE_REF as an env var in `make push-multiarch`

### DIFF
--- a/build.make
+++ b/build.make
@@ -185,24 +185,24 @@ $(CMDS:%=push-multiarch-%): push-multiarch-%: check-pull-base-ref build-%
 		done; \
 		docker manifest push -p $(IMAGE_NAME):$$tag; \
 	}; \
-	if [ $(PULL_BASE_REF) = "master" ]; then \
+	if [ ${PULL_BASE_REF} = "master" ]; then \
 			: "creating or overwriting canary image"; \
 			pushMultiArch canary; \
-	elif echo $(PULL_BASE_REF) | grep -q -e 'release-*' ; then \
+	elif echo ${PULL_BASE_REF} | grep -q -e 'release-*' ; then \
 			: "creating or overwriting canary image for release branch"; \
-			release_canary_tag=$$(echo $(PULL_BASE_REF) | cut -f2 -d '-')-canary; \
+			release_canary_tag=$$(echo ${PULL_BASE_REF} | cut -f2 -d '-')-canary; \
 			pushMultiArch $$release_canary_tag; \
-	elif docker pull $(IMAGE_NAME):$(PULL_BASE_REF) 2>&1 | tee /dev/stderr | grep -q "manifest for $(IMAGE_NAME):$(PULL_BASE_REF) not found"; then \
+	elif docker pull $(IMAGE_NAME):${PULL_BASE_REF} 2>&1 | tee /dev/stderr | grep -q "manifest for $(IMAGE_NAME):${PULL_BASE_REF} not found"; then \
 			: "creating release image"; \
-			pushMultiArch $(PULL_BASE_REF); \
+			pushMultiArch ${PULL_BASE_REF}; \
 	else \
-			: "ERROR: release image $(IMAGE_NAME):$(PULL_BASE_REF) already exists: a new tag is required!"; \
+			: "ERROR: release image $(IMAGE_NAME):${PULL_BASE_REF} already exists: a new tag is required!"; \
 			exit 1; \
 	fi
 
 .PHONY: check-pull-base-ref
 check-pull-base-ref:
-	if ! [ "$(PULL_BASE_REF)" ]; then \
+	if ! [ "${PULL_BASE_REF}" ]; then \
 		echo >&2 "ERROR: PULL_BASE_REF must be set to 'master', 'release-x.y', or a tag name."; \
 		exit 1; \
 	fi


### PR DESCRIPTION
The kubernetes-csi/livenessprobe postsubmit prowjob https://k8s-testgrid.appspot.com/sig-storage-image-build#post-livenessprobe-push-images is failing, I checked in the [logs](https://storage.googleapis.com/kubernetes-jenkins/logs/post-livenessprobe-push-images/1420453703948701696/build-log.txt) that the makefile var `PULL_BASE_REF` isn't defined but it's used here:

https://github.com/kubernetes-csi/csi-release-tools/blob/ac8108f12f64eb61f489aaf7df611d93e77a1332/build.make#L188-L201

Probably the intention was to refer to the env var instead, in any case this PR references it as an env var.

Update: Michelle pointed out that https://k8s-testgrid.appspot.com/sig-storage-image-build#post-livenessprobe-push-images succeeded before this PR got merged, it looks like PULL_BASE_REF was set from to outside to an empty value

```release-note
NONE
```

/cc @pohly @msau42 