### PR TITLE
Increase build timeout

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -16,9 +16,8 @@
 # To promote release images, see https://github.com/kubernetes/k8s.io/tree/HEAD/k8s.gcr.io/images/k8s-staging-sig-storage.
 
 # This must be specified in seconds. If omitted, defaults to 600s (10 mins).
-# Building three images in external-snapshotter takes roughly half an hour,
-# sometimes more.
-timeout: 3600s
+# Building three images in external-snapshotter takes more than an hour.
+timeout: 7200s
 # This prevents errors if you don't use both _GIT_TAG and _PULL_BASE_REF,
 # or any new substitutions added in the future.
 options:


### PR DESCRIPTION
Building 3 snapshot images are taking longer than an hour recently.  As a result, it timed out before finish building the snapshot validation webhook image.  That's why we only see snapshot-controller and CSI snapshotter sidecar images in the staging repo, but not the webhook one, when cutting release v5.0.0 for external-snapshotter.
https://k8s-testgrid.appspot.com/sig-storage-image-build#post-external-snapshotter-push-images

So we need to bump the timeout value.