### PR TITLE
Add support to build arm/v7 images

### DIFF
--- a/prow.sh
+++ b/prow.sh
@@ -78,7 +78,7 @@ version_to_git () {
 # the list of windows versions was matched from:
 # - https://hub.docker.com/_/microsoft-windows-nanoserver
 # - https://hub.docker.com/_/microsoft-windows-servercore
-configvar CSI_PROW_BUILD_PLATFORMS "linux amd64; linux ppc64le -ppc64le; linux s390x -s390x; linux arm -arm; linux arm64 -arm64; windows amd64 .exe nanoserver:1809 servercore:ltsc2019; windows amd64 .exe nanoserver:1909 servercore:1909; windows amd64 .exe nanoserver:2004 servercore:2004; windows amd64 .exe nanoserver:20H2 servercore:20H2; windows amd64 .exe nanoserver:ltsc2022 servercore:ltsc2022" "Go target platforms (= GOOS + GOARCH) and file suffix of the resulting binaries"
+configvar CSI_PROW_BUILD_PLATFORMS "linux amd64 amd64; linux ppc64le ppc64le -ppc64le; linux s390x s390x -s390x; linux arm arm -arm; linux arm64 arm64 -arm64; linux arm arm/v7 -armv7; windows amd64 amd64 .exe nanoserver:1809 servercore:ltsc2019; windows amd64 amd64 .exe nanoserver:1909 servercore:1909; windows amd64 amd64 .exe nanoserver:2004 servercore:2004; windows amd64 amd64 .exe nanoserver:20H2 servercore:20H2; windows amd64 amd64 .exe nanoserver:ltsc2022 servercore:ltsc2022" "Go target platforms (= GOOS + GOARCH) and file suffix of the resulting binaries"
 
 # If we have a vendor directory, then use it. We must be careful to only
 # use this for "make" invocations inside the project's repo itself because


### PR DESCRIPTION
Adds support to build arm/v7 images:

- I added another element in the BUILD_PLATFORM tuple that's the docker buildx platform (unfortunately it's arm/v7 which is not a valid GOARCH)
- Modified other locations to use the new element `buildx_platform` in the image tag

Logs:

```
❯ make push-multiarch PULL_BASE_REF=master IMAGE_TAGS=v3.1.0-canary REGISTRY_NAME=<registry> BUILD_PLATFORMS="linux amd64 amd64; linux ppc64le ppc64le -ppc64le; linux s390x s390x -s390x; linux arm arm -arm; linux arm64 arm64 -arm64; linux arm arm/v7 -armv7; windows amd64 amd64 .exe nanoserver:1809 servercore:ltsc2019; windows amd64 amd64 .exe nanoserver:1909 servercore:1909; windows amd64 amd64 .exe nanoserver:2004 servercore:2004; windows amd64 amd64 .exe nanoserver:20H2 servercore:20H2; windows amd64 amd64 .exe nanoserver:ltsc2022 servercore:ltsc2022"
if ! [ "master" ]; then \
        echo >&2 "ERROR: PULL_BASE_REF must be set to 'master', 'release-x.y', or a tag name."; \
        exit 1; \
fi
./release-tools/verify-go-version.sh "go"

======================================================
                  WARNING

  This projects is tested with Go v1.17.3.
  Your current Go version is v1.17.
  This may or may not be close enough.

  In particular test-gofmt and test-vendor
  are known to be sensitive to the version of
  Go.
======================================================

mkdir -p bin
# os_arch_seen captures all of the $os-$arch-$buildx_platform seen for the current binary
# that we want to build, if we've seen an $os-$arch-$buildx_platform before it means that
# we don't need to build it again, this is done to avoid building
# the windows binary multiple times (see the default value of $BUILD_PLATFORMS)
export os_arch_seen="" && echo 'linux amd64 amd64; linux ppc64le ppc64le -ppc64le; linux s390x s390x -s390x; linux arm arm -arm; linux arm64 arm64 -arm64; linux arm arm/v7 -armv7; windows amd64 amd64 .exe nanoserver:1809 servercore:ltsc2019; windows amd64 amd64 .exe nanoserver:1909 servercore:1909; windows amd64 amd64 .exe nanoserver:2004 servercore:2004; windows amd64 amd64 .exe nanoserver:20H2 servercore:20H2; windows amd64 amd64 .exe nanoserver:ltsc2022 servercore:ltsc2022' | tr ';' '\n' | while read -r os arch buildx_platform suffix base_image addon_image; do \
        os_arch_seen_pre=${os_arch_seen%%$os-$arch-$buildx_platform*}; \
        if ! [ ${#os_arch_seen_pre} = ${#os_arch_seen} ]; then \
                continue; \
        fi; \
        if ! (set -x; cd ./cmd/csi-provisioner && CGO_ENABLED=0 GOOS="$os" GOARCH="$arch" go build  -a -ldflags ' -X main.version=v3.0.0-30-gac7ae1051-dirty -extldflags "-static"' -o "/usr/local/google/home/mauriciopoppe/go/src/github.com/kubernetes-csi/external-provisioner/bin/csi-provisioner$suffix" .); then \
                echo "Building csi-provisioner for GOOS=$os GOARCH=$arch failed, see error(s) above."; \
                exit 1; \
        fi; \
        os_arch_seen+=";$os-$arch-$buildx_platform"; \
done
+ cd ./cmd/csi-provisioner
+ CGO_ENABLED=0
+ GOOS=linux
+ GOARCH=amd64
+ go build -a -ldflags ' -X main.version=v3.0.0-30-gac7ae1051-dirty -extldflags "-static"' -o /usr/local/google/home/mauriciopoppe/go/src/github.com/kubernetes-csi/external-provisioner/bin/csi-provisioner .
+ cd ./cmd/csi-provisioner
+ CGO_ENABLED=0
+ GOOS=linux
+ GOARCH=ppc64le
+ go build -a -ldflags ' -X main.version=v3.0.0-30-gac7ae1051-dirty -extldflags "-static"' -o /usr/local/google/home/mauriciopoppe/go/src/github.com/kubernetes-csi/external-provisioner/bin/csi-provisioner-ppc64le .
+ cd ./cmd/csi-provisioner
+ CGO_ENABLED=0
+ GOOS=linux
+ GOARCH=s390x
+ go build -a -ldflags ' -X main.version=v3.0.0-30-gac7ae1051-dirty -extldflags "-static"' -o /usr/local/google/home/mauriciopoppe/go/src/github.com/kubernetes-csi/external-provisioner/bin/csi-provisioner-s390x .
+ cd ./cmd/csi-provisioner
+ CGO_ENABLED=0
+ GOOS=linux
+ GOARCH=arm
+ go build -a -ldflags ' -X main.version=v3.0.0-30-gac7ae1051-dirty -extldflags "-static"' -o /usr/local/google/home/mauriciopoppe/go/src/github.com/kubernetes-csi/external-provisioner/bin/csi-provisioner-arm .
+ cd ./cmd/csi-provisioner
+ CGO_ENABLED=0
+ GOOS=linux
+ GOARCH=arm64
+ go build -a -ldflags ' -X main.version=v3.0.0-30-gac7ae1051-dirty -extldflags "-static"' -o /usr/local/google/home/mauriciopoppe/go/src/github.com/kubernetes-csi/external-provisioner/bin/csi-provisioner-arm64 .
+ cd ./cmd/csi-provisioner
+ CGO_ENABLED=0
+ GOOS=linux
+ GOARCH=arm
+ go build -a -ldflags ' -X main.version=v3.0.0-30-gac7ae1051-dirty -extldflags "-static"' -o /usr/local/google/home/mauriciopoppe/go/src/github.com/kubernetes-csi/external-provisioner/bin/csi-provisioner-armv7 .
+ cd ./cmd/csi-provisioner
+ CGO_ENABLED=0
+ GOOS=windows
+ GOARCH=amd64
+ go build -a -ldflags ' -X main.version=v3.0.0-30-gac7ae1051-dirty -extldflags "-static"' -o /usr/local/google/home/mauriciopoppe/go/src/github.com/kubernetes-csi/external-provisioner/bin/csi-provisioner.exe .
set -ex; \
export DOCKER_CLI_EXPERIMENTAL=enabled; \
docker buildx create  --use --name multiarchimage-buildertest; \
trap "docker buildx rm multiarchimage-buildertest" EXIT; \
dockerfile_linux=$(if [ -e ./cmd/csi-provisioner/Dockerfile ]; then echo ./cmd/csi-provisioner/Dockerfile; else echo Dockerfile; fi); \
dockerfile_windows=$(if [ -e ./cmd/csi-provisioner/Dockerfile.Windows ]; then echo ./cmd/csi-provisioner/Dockerfile.Windows; else echo Dockerfile.Windows; fi); \
if [ 'linux amd64 amd64; linux ppc64le ppc64le -ppc64le; linux s390x s390x -s390x; linux arm arm -arm; linux arm64 arm64 -arm64; linux arm arm/v7 -armv7; windows amd64 amd64 .exe nanoserver:1809 servercore:ltsc2019; windows amd64 amd64 .exe nanoserver:1909 servercore:1909; windows amd64 amd64 .exe nanoserver:2004 servercore:2004; windows amd64 amd64 .exe nanoserver:20H2 servercore:20H2; windows amd64 amd64 .exe nanoserver:ltsc2022 servercore:ltsc2022' ]; then build_platforms='linux amd64 amd64; linux ppc64le ppc64le -ppc64le; linux s390x s390x -s390x; linux arm arm -arm; linux arm64 arm64 -arm64; linux arm arm/v7 -armv7; windows amd64 amd64 .exe nanoserver:1809 servercore:ltsc2019; windows amd64 amd64 .exe nanoserver:1909 servercore:1909; windows amd64 amd64 .exe nanoserver:2004 servercore:2004; windows amd64 amd64 .exe nanoserver:20H2 servercore:20H2; windows amd64 amd64 .exe nanoserver:ltsc2022 servercore:ltsc2022'; else build_platforms="linux amd64"; fi; \
if ! [ -f "$dockerfile_windows" ]; then \
        build_platforms="$(echo "$build_platforms" | sed -e 's/windows *[^ ]* *[^ ]* *.exe *[^ ]* *[^ ]*//g' -e 's/; *;/;/g' -e 's/;[ ]*$//')"; \
fi; \
pushMultiArch () { \
        tag=$1; \
        echo "$build_platforms" | tr ';' '\n' | while read -r os arch buildx_platform suffix base_image addon_image; do \
                escaped_base_image=${base_image/:/-}; \
                escaped_buildx_platform=${buildx_platform//\//-}; \
                if ! [ -z $escaped_base_image ]; then escaped_base_image+="-"; fi; \
                docker buildx build --push \
                        --tag <registry>/csi-provisioner:$escaped_buildx_platform-$os-$escaped_base_image$tag \
                        --platform=$os/$buildx_platform \
                        --file $(eval echo \${dockerfile_$os}) \
                        --build-arg binary=./bin/csi-provisioner$suffix \
                        --build-arg ARCH=$arch \
                        --build-arg BASE_IMAGE=$base_image \
                        --build-arg ADDON_IMAGE=$addon_image \
                        --label revision=v3.0.0-30-gac7ae1051-dirty \
                        .; \
        done; \
        images=$(echo "$build_platforms" | tr ';' '\n' | while read -r os arch buildx_platform suffix base_image addon_image; do escaped_base_image=${base_image/:/-}; escaped_buildx_platform=${buildx_platform//\//-}; if ! [ -z $escaped_base_image ]; then escaped_base_image+="-"; fi; echo <registry>/csi-provisioner:$escaped_buildx_platform-$os-$escaped_base_image$tag; done); \
        docker manifest create --amend <registry>/csi-provisioner:$tag $images; \
        echo "$build_platforms" | tr ';' '\n' | while read -r os arch buildx_platform suffix base_image addon_image; do \
                if [ $os = "windows" ]; then \
                        escaped_base_image=${base_image/:/-}; \
                        if ! [ -z $escaped_base_image ]; then escaped_base_image+="-"; fi; \
                        image=<registry>/csi-provisioner:$arch-$os-$escaped_base_image$tag; \
                        os_version=$(docker manifest inspect mcr.microsoft.com/windows/${base_image} | grep "os.version" | head -n 1 | awk '{print $2}' | sed -e 's/"//g') || true; \
                        docker manifest annotate --os-version $os_version <registry>/csi-provisioner:$tag $image; \
                fi; \
        done; \
        docker manifest push -p <registry>/csi-provisioner:$tag; \
}; \
if [ master = "master" ]; then \
                : "creating or overwriting canary image"; \
                pushMultiArch canary; \
elif echo master | grep -q -e 'release-*' ; then \
                : "creating or overwriting canary image for release branch"; \
                release_canary_tag=$(echo master | cut -f2 -d '-')-canary; \
                pushMultiArch $release_canary_tag; \
elif docker pull <registry>/csi-provisioner:master 2>&1 | tee /dev/stderr | grep -q "manifest for <registry>/csi-provisioner:master not found"; then \
                : "creating release image"; \
                pushMultiArch master; \
else \
                : "ERROR: release image <registry>/csi-provisioner:master already exists: a new tag is required!"; \
                exit 1; \
fi
+ export DOCKER_CLI_EXPERIMENTAL=enabled
+ DOCKER_CLI_EXPERIMENTAL=enabled
+ docker buildx create --use --name multiarchimage-buildertest
multiarchimage-buildertest
+ trap 'docker buildx rm multiarchimage-buildertest' EXIT
++ '[' -e ./cmd/csi-provisioner/Dockerfile ']'
++ echo Dockerfile
+ dockerfile_linux=Dockerfile
++ '[' -e ./cmd/csi-provisioner/Dockerfile.Windows ']'
++ echo Dockerfile.Windows
+ dockerfile_windows=Dockerfile.Windows
+ '[' 'linux amd64 amd64; linux ppc64le ppc64le -ppc64le; linux s390x s390x -s390x; linux arm arm -arm; linux arm64 arm64 -arm64; linux arm arm/v7 -armv7; windows amd64 amd64 .exe nanoserver:1809 servercore:ltsc2019; windows amd64 amd64 .exe nanoserver:1909 servercore:1909; windows amd64 amd64 .exe nanoserver:2004 servercore:2004; windows amd64 amd64 .exe nanoserver:20H2 servercore:20H2; windows amd64 amd64 .exe nanoserver:ltsc2022 servercore:ltsc2022' ']'
+ build_platforms='linux amd64 amd64; linux ppc64le ppc64le -ppc64le; linux s390x s390x -s390x; linux arm arm -arm; linux arm64 arm64 -arm64; linux arm arm/v7 -armv7; windows amd64 amd64 .exe nanoserver:1809 servercore:ltsc2019; windows amd64 amd64 .exe nanoserver:1909 servercore:1909; windows amd64 amd64 .exe nanoserver:2004 servercore:2004; windows amd64 amd64 .exe nanoserver:20H2 servercore:20H2; windows amd64 amd64 .exe nanoserver:ltsc2022 servercore:ltsc2022'
+ '[' -f Dockerfile.Windows ']'
++ echo 'linux amd64 amd64; linux ppc64le ppc64le -ppc64le; linux s390x s390x -s390x; linux arm arm -arm; linux arm64 arm64 -arm64; linux arm arm/v7 -armv7; windows amd64 amd64 .exe nanoserver:1809 servercore:ltsc2019; windows amd64 amd64 .exe nanoserver:1909 servercore:1909; windows amd64 amd64 .exe nanoserver:2004 servercore:2004; windows amd64 amd64 .exe nanoserver:20H2 servercore:20H2; windows amd64 amd64 .exe nanoserver:ltsc2022 servercore:ltsc2022'
++ sed -e 's/windows *[^ ]* *[^ ]* *.exe *[^ ]* *[^ ]*//g' -e 's/; *;/;/g' -e 's/;[ ]*$//'
+ build_platforms='linux amd64 amd64; linux ppc64le ppc64le -ppc64le; linux s390x s390x -s390x; linux arm arm -arm; linux arm64 arm64 -arm64; linux arm arm/v7 -armv7'
+ '[' master = master ']'
+ : 'creating or overwriting canary image'
+ pushMultiArch canary
+ tag=canary
+ echo 'linux amd64 amd64; linux ppc64le ppc64le -ppc64le; linux s390x s390x -s390x; linux arm arm -arm; linux arm64 arm64 -arm64; linux arm arm/v7 -armv7'
+ tr ';' '\n'
+ read -r os arch buildx_platform suffix base_image addon_image
+ escaped_base_image=
+ escaped_buildx_platform=amd64
+ '[' -z ']'
++ eval echo '${dockerfile_linux}'
+++ echo Dockerfile
+ docker buildx build --push --tag <registry>/csi-provisioner:amd64-linux-canary --platform=linux/amd64 --file Dockerfile --build-arg binary=./bin/csi-provisioner --build-arg ARCH=amd64 --build-arg BASE_IMAGE= --build-arg ADDON_IMAGE= --label revision=v3.0.0-30-gac7ae1051-dirty .
[+] Building 13.8s (10/10) FINISHED
 => [internal] booting buildkit                                                                                          2.3s
 => => pulling image moby/buildkit:buildx-stable-1                                                                       0.2s
 => => creating container buildx_buildkit_multiarchimage-buildertest0                                                    2.1s
 => [internal] load build definition from Dockerfile                                                                     0.2s
 => => transferring dockerfile: 257B                                                                                     0.0s
 => [internal] load .dockerignore                                                                                        0.1s
 => => transferring context: 2B                                                                                          0.0s
 => [internal] load metadata for gcr.io/distroless/static:latest                                                         0.6s
 => [internal] load build context                                                                                        0.6s
 => => transferring context: 56.11MB                                                                                     0.5s
 => [1/2] FROM gcr.io/distroless/static:latest@sha256:8ad6f3ec70dad966479b9fb48da991138c72ba969859098ec689d1450c2e6c97   0.4s
 => => resolve gcr.io/distroless/static:latest@sha256:8ad6f3ec70dad966479b9fb48da991138c72ba969859098ec689d1450c2e6c97   0.0s
 => => sha256:2df365faf0e3007f983fadd7a65ba51d41b488eb2ed8fc70f4bf97043cfea560 803.83kB / 803.83kB                       0.1s
 => => extracting sha256:2df365faf0e3007f983fadd7a65ba51d41b488eb2ed8fc70f4bf97043cfea560                                0.3s
 => [2/2] COPY ./bin/csi-provisioner csi-provisioner                                                                     1.4s
 => exporting to image                                                                                                   8.2s
 => => exporting layers                                                                                                  2.6s
 => => exporting manifest sha256:8b211428d2e1c70bc244f22dc97d76890315bd7d2fa67bef68962d955506f12e                        0.0s
 => => exporting config sha256:0b7fd774c6230387be4738d4eca601128717f2bb3bfec7bf3a6fc317323eaf6f                          0.0s
 => => pushing layers                                                                                                    4.8s
 => => pushing manifest for <registry>/csi-provisioner:amd64-linux-canary@sha256:8b211428d2e1c70bc244  0.7s
 => [auth] mauriciopoppe-gke-dev/csi-provisioner:pull,push token for gcr.io                                              0.0s
 => [auth] mauriciopoppe-gke-dev/csi-provisioner:pull,push token for gcr.io                                              0.0s
+ read -r os arch buildx_platform suffix base_image addon_image
+ escaped_base_image=
+ escaped_buildx_platform=ppc64le
+ '[' -z ']'
++ eval echo '${dockerfile_linux}'
+++ echo Dockerfile
+ docker buildx build --push --tag <registry>/csi-provisioner:ppc64le-linux-canary --platform=linux/ppc64le --file Dockerfile --build-arg binary=./bin/csi-provisioner-ppc64le --build-arg ARCH=ppc64le --build-arg BASE_IMAGE= --build-arg ADDON_IMAGE= --label revision=v3.0.0-30-gac7ae1051-dirty .
[+] Building 7.7s (7/7) FINISHED
 => [internal] load build definition from Dockerfile                                                                     0.0s
 => => transferring dockerfile: 257B                                                                                     0.0s
 => [internal] load .dockerignore                                                                                        0.0s
 => => transferring context: 2B                                                                                          0.0s
 => [internal] load metadata for gcr.io/distroless/static:latest                                                         0.5s
 => [internal] load build context                                                                                        0.5s
 => => transferring context: 55.45MB                                                                                     0.5s
 => [1/2] FROM gcr.io/distroless/static:latest@sha256:8ad6f3ec70dad966479b9fb48da991138c72ba969859098ec689d1450c2e6c97   0.4s
 => => resolve gcr.io/distroless/static:latest@sha256:8ad6f3ec70dad966479b9fb48da991138c72ba969859098ec689d1450c2e6c97   0.0s
 => => sha256:28fafa2640bec5df6202b9856d72646cf7b1d72bd598d2a958017887b2b32670 803.84kB / 803.84kB                       0.1s
 => => extracting sha256:28fafa2640bec5df6202b9856d72646cf7b1d72bd598d2a958017887b2b32670                                0.3s
 => [2/2] COPY ./bin/csi-provisioner-ppc64le csi-provisioner                                                             1.4s
 => exporting to image                                                                                                   5.1s
 => => exporting layers                                                                                                  2.3s
 => => exporting manifest sha256:c5975bf31589c43d6b70c7db9fa942082c3a985c8a5e2dd1c8110dc1aaa2339e                        0.0s
 => => exporting config sha256:dd8ffaa92edf9b7cec6c0a4cbad003d6f6066d53e21d968e6261dbf1ef75fac6                          0.0s
 => => pushing layers                                                                                                    2.0s
 => => pushing manifest for <registry>/csi-provisioner:ppc64le-linux-canary@sha256:c5975bf31589c43d6b  0.8s
+ read -r os arch buildx_platform suffix base_image addon_image
+ escaped_base_image=
+ escaped_buildx_platform=s390x
+ '[' -z ']'
++ eval echo '${dockerfile_linux}'
+++ echo Dockerfile
+ docker buildx build --push --tag <registry>/csi-provisioner:s390x-linux-canary --platform=linux/s390x --file Dockerfile --build-arg binary=./bin/csi-provisioner-s390x --build-arg ARCH=s390x --build-arg BASE_IMAGE= --build-arg ADDON_IMAGE= --label revision=v3.0.0-30-gac7ae1051-dirty .
[+] Building 7.9s (7/7) FINISHED
 => [internal] load build definition from Dockerfile                                                                     0.0s
 => => transferring dockerfile: 257B                                                                                     0.0s
 => [internal] load .dockerignore                                                                                        0.0s
 => => transferring context: 2B                                                                                          0.0s
 => [internal] load metadata for gcr.io/distroless/static:latest                                                         0.4s
 => [internal] load build context                                                                                        0.6s
 => => transferring context: 57.45MB                                                                                     0.6s
 => [1/2] FROM gcr.io/distroless/static:latest@sha256:8ad6f3ec70dad966479b9fb48da991138c72ba969859098ec689d1450c2e6c97   0.4s
 => => resolve gcr.io/distroless/static:latest@sha256:8ad6f3ec70dad966479b9fb48da991138c72ba969859098ec689d1450c2e6c97   0.0s
 => => sha256:fcc4c79626a7112d1ea2f30dc4b4de829791501046aab457271aaf4d018b5efe 803.83kB / 803.83kB                       0.1s
 => => extracting sha256:fcc4c79626a7112d1ea2f30dc4b4de829791501046aab457271aaf4d018b5efe                                0.3s
 => [2/2] COPY ./bin/csi-provisioner-s390x csi-provisioner                                                               1.3s
 => exporting to image                                                                                                   5.4s
 => => exporting layers                                                                                                  2.7s
 => => exporting manifest sha256:3f0653728d7095c268616e2b2acc08c0db39a777a735bba784984e3ba2a7a882                        0.0s
 => => exporting config sha256:50bddc4f22bc2345bd92e938880740e89652e7d236c41731c0d056490ed2d90e                          0.0s
 => => pushing layers                                                                                                    1.9s
 => => pushing manifest for <registry>/csi-provisioner:s390x-linux-canary@sha256:3f0653728d7095c26861  0.7s
+ read -r os arch buildx_platform suffix base_image addon_image
+ escaped_base_image=
+ escaped_buildx_platform=arm
+ '[' -z ']'
++ eval echo '${dockerfile_linux}'
+++ echo Dockerfile
+ docker buildx build --push --tag <registry>/csi-provisioner:arm-linux-canary --platform=linux/arm --file Dockerfile --build-arg binary=./bin/csi-provisioner-arm --build-arg ARCH=arm --build-arg BASE_IMAGE= --build-arg ADDON_IMAGE= --label revision=v3.0.0-30-gac7ae1051-dirty .
[+] Building 7.1s (7/7) FINISHED
 => [internal] load build definition from Dockerfile                                                                     0.0s
 => => transferring dockerfile: 257B                                                                                     0.0s
 => [internal] load .dockerignore                                                                                        0.0s
 => => transferring context: 2B                                                                                          0.0s
 => [internal] load metadata for gcr.io/distroless/static:latest                                                         0.4s
 => [internal] load build context                                                                                        0.5s
 => => transferring context: 50.09MB                                                                                     0.5s
 => [1/2] FROM gcr.io/distroless/static:latest@sha256:8ad6f3ec70dad966479b9fb48da991138c72ba969859098ec689d1450c2e6c97   0.4s
 => => resolve gcr.io/distroless/static:latest@sha256:8ad6f3ec70dad966479b9fb48da991138c72ba969859098ec689d1450c2e6c97   0.0s
 => => sha256:19def8af554c6b8e888453e416396087f974a189bf683a0c8a20da56818a13e0 803.83kB / 803.83kB                       0.1s
 => => extracting sha256:19def8af554c6b8e888453e416396087f974a189bf683a0c8a20da56818a13e0                                0.3s
 => [2/2] COPY ./bin/csi-provisioner-arm csi-provisioner                                                                 1.2s
 => exporting to image                                                                                                   4.7s
 => => exporting layers                                                                                                  2.2s
 => => exporting manifest sha256:2a94fbda34bed2d6374c60046c222e2d10f5eb17eb2ef6a270f5cda437e06eb3                        0.0s
 => => exporting config sha256:14da2f2870d977aa255996420076841ee3760fe5ff7d856138ce76ba46e26562                          0.0s
 => => pushing layers                                                                                                    1.7s
 => => pushing manifest for <registry>/csi-provisioner:arm-linux-canary@sha256:2a94fbda34bed2d6374c60  0.7s
+ read -r os arch buildx_platform suffix base_image addon_image
+ escaped_base_image=
+ escaped_buildx_platform=arm64
+ '[' -z ']'
++ eval echo '${dockerfile_linux}'
+++ echo Dockerfile
+ docker buildx build --push --tag <registry>/csi-provisioner:arm64-linux-canary --platform=linux/arm64 --file Dockerfile --build-arg binary=./bin/csi-provisioner-arm64 --build-arg ARCH=arm64 --build-arg BASE_IMAGE= --build-arg ADDON_IMAGE= --label revision=v3.0.0-30-gac7ae1051-dirty .
[+] Building 7.5s (7/7) FINISHED
 => [internal] load build definition from Dockerfile                                                                                                                                                                                                      0.0s
 => => transferring dockerfile: 257B                                                                                                                                                                                                                      0.0s
 => [internal] load .dockerignore                                                                                                                                                                                                                         0.0s
 => => transferring context: 2B                                                                                                                                                                                                                           0.0s
 => [internal] load metadata for gcr.io/distroless/static:latest                                                                                                                                                                                          0.4s
 => [internal] load build context                                                                                                                                                                                                                         0.6s
 => => transferring context: 55.15MB                                                                                                                                                                                                                      0.6s
 => [1/2] FROM gcr.io/distroless/static:latest@sha256:8ad6f3ec70dad966479b9fb48da991138c72ba969859098ec689d1450c2e6c97                                                                                                                                    0.4s
 => => resolve gcr.io/distroless/static:latest@sha256:8ad6f3ec70dad966479b9fb48da991138c72ba969859098ec689d1450c2e6c97                                                                                                                                    0.0s
 => => sha256:dbcab61d5a5a806aee6156f2e22c601a52119ca8eaeb8fcd08187f22c35d9b88 803.83kB / 803.83kB                                                                                                                                                        0.1s
 => => extracting sha256:dbcab61d5a5a806aee6156f2e22c601a52119ca8eaeb8fcd08187f22c35d9b88                                                                                                                                                                 0.3s
 => [2/2] COPY ./bin/csi-provisioner-arm64 csi-provisioner                                                                                                                                                                                                1.3s
 => exporting to image                                                                                                                                                                                                                                    5.0s
 => => exporting layers                                                                                                                                                                                                                                   2.4s
 => => exporting manifest sha256:86865fe03554aa723c63c186ef4dbca69eabaa8592ffaaceadaf86ae55a4b5c9                                                                                                                                                         0.0s
 => => exporting config sha256:d8bdcb89767abd8b978541db90b47e4b543b63a46a0519340eb3fbda4397f788                                                                                                                                                           0.0s
 => => pushing layers                                                                                                                                                                                                                                     1.8s
 => => pushing manifest for <registry>/csi-provisioner:arm64-linux-canary@sha256:86865fe03554aa723c63c186ef4dbca69eabaa8592ffaaceadaf86ae55a4b5c9                                                                                       0.7s
+ read -r os arch buildx_platform suffix base_image addon_image
+ escaped_base_image=
+ escaped_buildx_platform=arm-v7
+ '[' -z ']'
++ eval echo '${dockerfile_linux}'
+++ echo Dockerfile
+ docker buildx build --push --tag <registry>/csi-provisioner:arm-v7-linux-canary --platform=linux/arm/v7 --file Dockerfile --build-arg binary=./bin/csi-provisioner-armv7 --build-arg ARCH=arm --build-arg BASE_IMAGE= --build-arg ADDON_IMAGE= --label revision=v3.0.0-30-gac7ae1051-dirty .
[+] Building 6.4s (7/7) FINISHED
 => [internal] load build definition from Dockerfile                                                                                                                                                                                                      0.0s
 => => transferring dockerfile: 257B                                                                                                                                                                                                                      0.0s
 => [internal] load .dockerignore                                                                                                                                                                                                                         0.0s
 => => transferring context: 2B                                                                                                                                                                                                                           0.0s
 => [internal] load metadata for gcr.io/distroless/static:latest                                                                                                                                                                                          0.1s
 => [internal] load build context                                                                                                                                                                                                                         0.4s
 => => transferring context: 50.09MB                                                                                                                                                                                                                      0.4s
 => CACHED [1/2] FROM gcr.io/distroless/static:latest@sha256:8ad6f3ec70dad966479b9fb48da991138c72ba969859098ec689d1450c2e6c97                                                                                                                             0.0s
 => => resolve gcr.io/distroless/static:latest@sha256:8ad6f3ec70dad966479b9fb48da991138c72ba969859098ec689d1450c2e6c97                                                                                                                                    0.0s
 => [2/2] COPY ./bin/csi-provisioner-armv7 csi-provisioner                                                                                                                                                                                                1.2s
 => exporting to image                                                                                                                                                                                                                                    4.5s
 => => exporting layers                                                                                                                                                                                                                                   2.2s
 => => exporting manifest sha256:738aec0db4438ac0b9aff713b09effb98d80af881cd07808f7a8612d720336b8                                                                                                                                                         0.0s
 => => exporting config sha256:753724384c6b2c695fab50a024f09c1be87711d9ed927566b49940f370d238ee                                                                                                                                                           0.0s
 => => pushing layers                                                                                                                                                                                                                                     1.7s
 => => pushing manifest for <registry>/csi-provisioner:arm-v7-linux-canary@sha256:738aec0db4438ac0b9aff713b09effb98d80af881cd07808f7a8612d720336b8                                                                                      0.6s
+ read -r os arch buildx_platform suffix base_image addon_image
++ echo 'linux amd64 amd64; linux ppc64le ppc64le -ppc64le; linux s390x s390x -s390x; linux arm arm -arm; linux arm64 arm64 -arm64; linux arm arm/v7 -armv7'
++ tr ';' '\n'
++ read -r os arch buildx_platform suffix base_image addon_image
++ escaped_base_image=
++ escaped_buildx_platform=amd64
++ '[' -z ']'
++ echo <registry>/csi-provisioner:amd64-linux-canary
++ read -r os arch buildx_platform suffix base_image addon_image
++ escaped_base_image=
++ escaped_buildx_platform=ppc64le
++ '[' -z ']'
++ echo <registry>/csi-provisioner:ppc64le-linux-canary
++ read -r os arch buildx_platform suffix base_image addon_image
++ escaped_base_image=
++ escaped_buildx_platform=s390x
++ '[' -z ']'
++ echo <registry>/csi-provisioner:s390x-linux-canary
++ read -r os arch buildx_platform suffix base_image addon_image
++ escaped_base_image=
++ escaped_buildx_platform=arm
++ '[' -z ']'
++ echo <registry>/csi-provisioner:arm-linux-canary
++ read -r os arch buildx_platform suffix base_image addon_image
++ escaped_base_image=
++ escaped_buildx_platform=arm64
++ '[' -z ']'
++ echo <registry>/csi-provisioner:arm64-linux-canary
++ read -r os arch buildx_platform suffix base_image addon_image
++ escaped_base_image=
++ escaped_buildx_platform=arm-v7
++ '[' -z ']'
++ echo <registry>/csi-provisioner:arm-v7-linux-canary
++ read -r os arch buildx_platform suffix base_image addon_image
+ images='<registry>/csi-provisioner:amd64-linux-canary
<registry>/csi-provisioner:ppc64le-linux-canary
<registry>/csi-provisioner:s390x-linux-canary
<registry>/csi-provisioner:arm-linux-canary
<registry>/csi-provisioner:arm64-linux-canary
<registry>/csi-provisioner:arm-v7-linux-canary'
+ docker manifest create --amend <registry>/csi-provisioner:canary <registry>/csi-provisioner:amd64-linux-canary <registry>/csi-provisioner:ppc64le-linux-canary <registry>/csi-provisioner:s390x-linux-canary <registry>/csi-provisioner:arm-linux-canary <registry>/csi-provisioner:arm64-linux-canary <registry>/csi-provisioner:arm-v7-linux-canary
Created manifest list <registry>/csi-provisioner:canary
+ echo 'linux amd64 amd64; linux ppc64le ppc64le -ppc64le; linux s390x s390x -s390x; linux arm arm -arm; linux arm64 arm64 -arm64; linux arm arm/v7 -armv7'
+ tr ';' '\n'
+ read -r os arch buildx_platform suffix base_image addon_image
+ '[' linux = windows ']'
+ read -r os arch buildx_platform suffix base_image addon_image
+ '[' linux = windows ']'
+ read -r os arch buildx_platform suffix base_image addon_image
+ '[' linux = windows ']'
+ read -r os arch buildx_platform suffix base_image addon_image
+ '[' linux = windows ']'
+ read -r os arch buildx_platform suffix base_image addon_image
+ '[' linux = windows ']'
+ read -r os arch buildx_platform suffix base_image addon_image
+ '[' linux = windows ']'
+ read -r os arch buildx_platform suffix base_image addon_image
+ docker manifest push -p <registry>/csi-provisioner:canary
sha256:1f87c0828345bf27e515d0d6e8aefd61b6b4f93a938bffe47cd090dfa5b3cbbc
+ docker buildx rm multiarchimage-buildertest
```

Fixes #180 

/cc @pohly