### PR TITLE
correct kube version condition check for default_csi_snapshotter_version func

### DIFF
--- a/prow.sh
+++ b/prow.sh
@@ -351,7 +351,7 @@ configvar CSI_PROW_E2E_ALPHA_GATES "$(get_versioned_variable CSI_PROW_E2E_ALPHA_
 
 # Which external-snapshotter tag to use for the snapshotter CRD and snapshot-controller deployment
 default_csi_snapshotter_version () {
-	if [ "${CSI_PROW_KUBERNETES_VERSION}" = "latest" ] || [ "${CSI_PROW_DRIVER_CANARY}" = "canary" ]; then
+	if [ "${CSI_PROW_KUBERNETES_VERSION}" == "latest" ] || [ "${CSI_PROW_DRIVER_CANARY}" == "canary" ]; then
 		echo "master"
 	else
 		echo "v3.0.2"


### PR DESCRIPTION
Additional note for reviewer:

The csi snapshotter would be picked as `v3.0.2` regardless of the KUBE version being latest due to the wrong condition check. This PR correct the same.

Signed-off-by: Humble Chirammal <hchiramm@redhat.com>