### PR TITLE
prow.sh: bump Kubernetes to v1.22.0

### DIFF
--- a/prow.sh
+++ b/prow.sh
@@ -121,7 +121,7 @@ configvar CSI_PROW_BUILD_JOB true "building code in repo enabled"
 # use the same settings as for "latest" Kubernetes. This works
 # as long as there are no breaking changes in Kubernetes, like
 # deprecating or changing the implementation of an alpha feature.
-configvar CSI_PROW_KUBERNETES_VERSION 1.17.0 "Kubernetes"
+configvar CSI_PROW_KUBERNETES_VERSION 1.22.0 "Kubernetes"
 
 # CSI_PROW_KUBERNETES_VERSION reduced to first two version numbers and
 # with underscore (1_13 instead of 1.13.3) and in uppercase (LATEST


### PR DESCRIPTION
This update is necessary because the default driver
version (csi-driver-host-path v1.8.0) no longer supports Kubernetes v1.17.0 (it
needs the v1 CSIDriver API).

1.22 is the oldest supported version at this point. This matches what we are
using as base in Prow at the moment. v1.22.0 is what the current kind has
pre-built images for.