### PR TITLE
prow.sh: update snapshotter version

### DIFF
--- a/prow.sh
+++ b/prow.sh
@@ -360,7 +360,7 @@ default_csi_snapshotter_version () {
 	if [ "${CSI_PROW_KUBERNETES_VERSION}" = "latest" ] || [ "${CSI_PROW_DRIVER_CANARY}" = "canary" ]; then
 		echo "master"
 	else
-		echo "v3.0.2"
+		echo "v4.0.0"
 	fi
 }
 configvar CSI_SNAPSHOTTER_VERSION "$(default_csi_snapshotter_version)" "external-snapshotter version tag"


### PR DESCRIPTION
The right snapshotter for Kubernetes 1.22 is v4.0.0.