### PR TITLE
 release tools update to 1.19

### DIFF
--- a/prow.sh
+++ b/prow.sh
@@ -86,7 +86,7 @@ configvar CSI_PROW_BUILD_PLATFORMS "linux amd64 amd64; linux ppc64le ppc64le -pp
 # which is disabled with GOFLAGS=-mod=vendor).
 configvar GOFLAGS_VENDOR "$( [ -d vendor ] && echo '-mod=vendor' )" "Go flags for using the vendor directory"
 
-configvar CSI_PROW_GO_VERSION_BUILD "1.18" "Go version for building the component" # depends on component's source code
+configvar CSI_PROW_GO_VERSION_BUILD "1.19" "Go version for building the component" # depends on component's source code
 configvar CSI_PROW_GO_VERSION_E2E "" "override Go version for building the Kubernetes E2E test suite" # normally doesn't need to be set, see install_e2e
 configvar CSI_PROW_GO_VERSION_SANITY "${CSI_PROW_GO_VERSION_BUILD}" "Go version for building the csi-sanity test suite" # depends on CSI_PROW_SANITY settings below
 configvar CSI_PROW_GO_VERSION_KIND "${CSI_PROW_GO_VERSION_BUILD}" "Go version for building 'kind'" # depends on CSI_PROW_KIND_VERSION below


### PR DESCRIPTION
Signed-off-by: Humble Chirammal <hchiramm@redhat.com>

Additional note for reviewer:

It seems to me that, this mention of 1.18 is causing the CI to fail while doing test-vendor in imported project. (https://prow.k8s.io/view/gs/kubernetes-jenkins/pr-logs/pull/kubernetes-csi_csi-driver-iscsi/137/pull-kubernetes-csi-csi-driver-iscsi/1567026945609175040)

https://github.com/kubernetes-csi/csi-driver-iscsi/pull/137#issuecomment-1237703595

After having this patch in place only `test-subtree` fails in CI which is expected: (https://prow.k8s.io/view/gs/kubernetes-jenkins/pr-logs/pull/kubernetes-csi_csi-driver-iscsi/137/pull-kubernetes-csi-csi-driver-iscsi/1567035242248671232)
```
 ### test-subtree:
./release-tools/verify-subtree.sh release-tools
Directory 'release-tools' contains non-upstream changes:
commit 843229e03b405a0732d5f8cd55fb268d5ee76b4a
Author: Humble Chirammal <hchiramm@redhat.com>
Date:   Tue Sep 6 11:50:47 2022 +0530
    release tools update to 1.19
    
    Signed-off-by: Humble Chirammal <hchiramm@redhat.com>
make: *** [release-tools/build.make:285: test-subtree] Error 1 
```
