### PR TITLE
Changes to enable volume mode conversion feature in prow jobs

### DIFF
--- a/prow.sh
+++ b/prow.sh
@@ -786,7 +786,6 @@ install_snapshot_crds() {
 
 # Enable feature flags in the snapshot-controller.
 enable_snapshot_controller_feature_flags () {
-  SNAPSHOT_CONTROLLER_YAML="${CSI_PROW_WORK}/snapshot-controller.yaml"
   if volume_mode_conversion; then
     echo "Deploying snapshot-controller with --prevent-volume-mode-conversion=true"
     sed -i -e 's/# end snapshot controller args/- \"--prevent-volume-mode-conversion=true\"\n            # end snapshot controller args/' "${SNAPSHOT_CONTROLLER_YAML}"
@@ -795,11 +794,16 @@ enable_snapshot_controller_feature_flags () {
 
 # Install snapshot controller and associated RBAC, retrying until the pod is running.
 install_snapshot_controller() {
-  CONTROLLER_DIR="https://raw.githubusercontent.com/kubernetes-csi/external-snapshotter/${CSI_SNAPSHOTTER_VERSION}"
   if [[ ${REPO_DIR} == *"external-snapshotter"* ]]; then
-      CONTROLLER_DIR="${REPO_DIR}"
+      SNAPSHOT_RBAC_YAML="${REPO_DIR}/deploy/kubernetes/snapshot-controller/rbac-snapshot-controller.yaml"
+      SNAPSHOT_CONTROLLER_YAML="${REPO_DIR}/deploy/kubernetes/snapshot-controller/setup-snapshot-controller.yaml"
+  else
+      CONTROLLER_DIR="https://raw.githubusercontent.com/kubernetes-csi/external-snapshotter/${CSI_SNAPSHOTTER_VERSION}"
+      SNAPSHOT_RBAC_YAML="${CONTROLLER_DIR}/deploy/kubernetes/snapshot-controller/rbac-snapshot-controller.yaml"
+      run curl "${CONTROLLER_DIR}/deploy/kubernetes/snapshot-controller/setup-snapshot-controller.yaml" --output "${CSI_PROW_WORK}/snapshot-controller.yaml" --silent --location
+      SNAPSHOT_CONTROLLER_YAML="${CSI_PROW_WORK}/snapshot-controller.yaml"
   fi
-  SNAPSHOT_RBAC_YAML="${CONTROLLER_DIR}/deploy/kubernetes/snapshot-controller/rbac-snapshot-controller.yaml"
+
   echo "kubectl apply -f ${SNAPSHOT_RBAC_YAML}"
   # Ignore: Double quote to prevent globbing and word splitting.
   # shellcheck disable=SC2086
@@ -818,8 +822,6 @@ install_snapshot_controller() {
     sleep 10
   done
 
-  run curl "${CONTROLLER_DIR}/deploy/kubernetes/snapshot-controller/setup-snapshot-controller.yaml" --output "${CSI_PROW_WORK}/snapshot-controller.yaml" --silent --location
-  SNAPSHOT_CONTROLLER_YAML="${CSI_PROW_WORK}/snapshot-controller.yaml"
   enable_snapshot_controller_feature_flags || die "failed to enable snapshot-controller feature flags"
 
   if [[ ${REPO_DIR} == *"external-snapshotter"* ]]; then

--- a/prow.sh
+++ b/prow.sh
@@ -864,9 +864,9 @@ install_snapshot_controller() {
               echo "$line"
           done)"
           if ! echo "$modified" | kubectl apply -f -; then
-            echo "modified version of $i:"
-            echo "$modified"
-            exit 1
+              echo "modified version of $i:"
+              echo "$modified"
+              exit 1
           fi
       done
   elif [ "${CSI_PROW_DRIVER_CANARY}" = "canary" ]; then
@@ -877,13 +877,13 @@ install_snapshot_controller() {
       modified="$(echo "$yaml" | sed -e "s;image: .*/\([^/:]*\):.*;image: ${CSI_PROW_DRIVER_CANARY_REGISTRY}/\1:canary;")"
       diff <(echo "$yaml") <(echo "$modified")
       if ! echo "$modified" | kubectl apply -f -; then
-        echo "modified version of $SNAPSHOT_CONTROLLER_YAML:"
-        echo "$modified"
-        exit 1
+          echo "modified version of $SNAPSHOT_CONTROLLER_YAML:"
+          echo "$modified"
+          exit 1
       fi
   else
-    echo "kubectl apply -f $SNAPSHOT_CONTROLLER_YAML"
-    kubectl apply -f "$SNAPSHOT_CONTROLLER_YAML"
+      echo "kubectl apply -f $SNAPSHOT_CONTROLLER_YAML"
+      kubectl apply -f "$SNAPSHOT_CONTROLLER_YAML"
   fi
 
   cnt=0


### PR DESCRIPTION
This PR does the following:
- Updates snapshot-controller manifest to enable `--prevent-volume-mode-conversion` if `VOLUME_MODE_CONVERSION_TESTS` is passed to the prow job. 
- Refactor `install_snapshot_controller()` in prow.sh

Related to https://github.com/kubernetes-csi/csi-driver-host-path/pull/379 and https://github.com/kubernetes-csi/external-snapshotter/pull/790

```release-note
Update prow.sh to enabled --prevent-volume-mode-conversion if VOLUME_MODE_CONVERSION_TESTS is set 
```