### PR TITLE
Set CSI hostpath driver version to master if canary run

### DIFF
--- a/prow.sh
+++ b/prow.sh
@@ -196,7 +196,14 @@ kindest/node:v1.18.20@sha256:738cdc23ed4be6cc0b7ea277a2ebcc454c8373d7d8fb991a7fc
 # If the deployment script is called with CSI_PROW_TEST_DRIVER=<file name> as
 # environment variable, then it must write a suitable test driver configuration
 # into that file in addition to installing the driver.
-configvar CSI_PROW_DRIVER_VERSION "v1.8.0" "CSI driver version"
+default_csi_prow_driver_version () {
+    if [ "${CSI_PROW_KUBERNETES_VERSION}" = "latest" ] || [ "${CSI_PROW_DRIVER_CANARY}" = "canary" ]; then
+        echo "master"
+    else
+        echo "v1.10.0"
+    fi
+}
+configvar CSI_PROW_DRIVER_VERSION "$(default_csi_prow_driver_version)" "CSI driver version"
 configvar CSI_PROW_DRIVER_REPO https://github.com/kubernetes-csi/csi-driver-host-path "CSI driver repo"
 configvar CSI_PROW_DEPLOYMENT "" "deployment"
 configvar CSI_PROW_DEPLOYMENT_SUFFIX "" "additional suffix in kubernetes-x.yy[suffix].yaml files"


### PR DESCRIPTION
Even if `CSI_PROW_HOSTPATH_CANARY` is set to `canary`, the prow job runs with CSI hostpath driver version set to the default (currently `v1.8.0`)
This PR sets it to master for canary runs. 

Example prow run with the issue - https://prow.k8s.io/log?container=test&id=1606218480988721152&job=pull-kubernetes-csi-external-provisioner-canary

```release-note
Set CSI hostpath driver version to master for canary prow jobs
```