### PR TITLE
Update registry k8s.gcr.io -> registry.k8s.io

### DIFF
--- a/SIDECAR_RELEASE_PROCESS.md
+++ b/SIDECAR_RELEASE_PROCESS.md
@@ -102,9 +102,9 @@ naming convention `<hostpath-deployment-version>-on-<kubernetes-version>`.
 1. If release was a new major/minor version, create a new `release-<minor>`
    branch at that commit.
 1. Check [image build status](https://k8s-testgrid.appspot.com/sig-storage-image-build).
-1. Promote images from k8s-staging-sig-storage to k8s.gcr.io/sig-storage. From
+1. Promote images from k8s-staging-sig-storage to registry.k8s.io/sig-storage. From
    the [k8s image
-   repo](https://github.com/kubernetes/k8s.io/tree/HEAD/k8s.gcr.io/images/k8s-staging-sig-storage),
+   repo](https://github.com/kubernetes/k8s.io/tree/HEAD/registry.k8s.io/images/k8s-staging-sig-storage),
    run `./generate.sh > images.yaml`, and send a PR with the updated images.
    Once merged, the image promoter will copy the images from staging to prod.
 1. Update [kubernetes-csi/docs](https://github.com/kubernetes-csi/docs) sidecar

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -13,7 +13,7 @@
 # See https://github.com/kubernetes/test-infra/blob/HEAD/config/jobs/image-pushing/README.md
 # for more details on image pushing process in Kubernetes.
 #
-# To promote release images, see https://github.com/kubernetes/k8s.io/tree/HEAD/k8s.gcr.io/images/k8s-staging-sig-storage.
+# To promote release images, see https://github.com/kubernetes/k8s.io/tree/HEAD/registry.k8s.io/images/k8s-staging-sig-storage.
 
 # This must be specified in seconds. If omitted, defaults to 600s (10 mins).
 # Building three images in external-snapshotter takes more than an hour.


### PR DESCRIPTION
This PR updates the registry from k8s.gcr.io to registry.k8s.io

Issue: https://github.com/kubernetes/k8s.io/issues/4738

Ref change: https://github.com/kubernetes-sigs/gcp-compute-persistent-disk-csi-driver/pull/1151#discussion_r1110158081