### PR TITLE
Update cloudbuild image

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -26,7 +26,7 @@ steps:
   # The image must contain bash and curl. Ideally it should also contain
   # the desired version of Go (currently defined in release-tools/prow.sh),
   # but that just speeds up the build and is not required.
-  - name: 'gcr.io/k8s-staging-test-infra/gcb-docker-gcloud:v20210917-12df099d55'
+  - name: 'gcr.io/k8s-testimages/gcb-docker-gcloud:v20230424-910a2a439d'
     entrypoint: ./.cloudbuild.sh
     env:
     - GIT_TAG=${_GIT_TAG}


### PR DESCRIPTION
Try to fix build failures:
https://storage.googleapis.com/kubernetes-jenkins/logs/post-external-provisioner-push-images/1650605297175105536/build-log.txt

Looks like go 1.20 added a new requirement to dynamically link to libresolv.so, and our image builder is based on alpine which doesn't support it:
https://github.com/golang/go/issues/59305