### PR TITLE
Pin buildkit to v0.10.6 to workaround v0.11 bug with docker manifest

### DIFF
--- a/build.make
+++ b/build.make
@@ -148,7 +148,7 @@ DOCKER_BUILDX_CREATE_ARGS ?=
 $(CMDS:%=push-multiarch-%): push-multiarch-%: check-pull-base-ref build-%
 	set -ex; \
 	export DOCKER_CLI_EXPERIMENTAL=enabled; \
-	docker buildx create $(DOCKER_BUILDX_CREATE_ARGS) --use --name multiarchimage-buildertest; \
+	docker buildx create $(DOCKER_BUILDX_CREATE_ARGS) --use --name multiarchimage-buildertest --driver-opt image=moby/buildkit:v0.10.6; \
 	trap "docker buildx rm multiarchimage-buildertest" EXIT; \
 	dockerfile_linux=$$(if [ -e ./$(CMDS_DIR)/$*/Dockerfile ]; then echo ./$(CMDS_DIR)/$*/Dockerfile; else echo Dockerfile; fi); \
 	dockerfile_windows=$$(if [ -e ./$(CMDS_DIR)/$*/Dockerfile.Windows ]; then echo ./$(CMDS_DIR)/$*/Dockerfile.Windows; else echo Dockerfile.Windows; fi); \


### PR DESCRIPTION
Workaround https://github.com/docker/cli/issues/3969

Build failure: https://storage.googleapis.com/kubernetes-jenkins/logs/post-external-provisioner-push-images/1650918675659624448/build-log.txt