### PR TITLE
pull-test.sh: avoid "git subtree pull" error

### DIFF
--- a/pull-test.sh
+++ b/pull-test.sh
@@ -25,6 +25,7 @@ CSI_RELEASE_TOOLS_DIR="$(pwd)"
 
 # Update the other repo.
 cd "$PULL_TEST_REPO_DIR"
+git reset --hard # Shouldn't be necessary, but somehow is to avoid "fatal: working tree has modifications.  Cannot add." (https://stackoverflow.com/questions/3623351/git-subtree-pull-says-that-the-working-tree-has-modifications-but-git-status-sa)
 git subtree pull --squash --prefix=release-tools "$CSI_RELEASE_TOOLS_DIR" master
 git log -n2
 


### PR DESCRIPTION
Without a prior `git reset --hard`, `git subtree pull` fails with:

    fatal: working tree has modifications.  Cannot add.

Debugging with -d doesn't show any explanation and neither `git diff` nor `git diff-index` show any modifications. The `git reset --hard` shouldn't be necessary.