### PR TITLE
Fix typo

### DIFF
--- a/verify-logcheck.sh
+++ b/verify-logcheck.sh
@@ -33,5 +33,5 @@ trap 'rm -rf "${CSI_LIB_UTIL_TEMP}"' EXIT
 
 echo "Installing logcheck to temp dir: sigs.k8s.io/logtools/logcheck@v${LOGCHECK_VERSION}"
 GOBIN="${CSI_LIB_UTIL_TEMP}" go install "sigs.k8s.io/logtools/logcheck@v${LOGCHECK_VERSION}"
-echo "Verifing logcheck: ${CSI_LIB_UTIL_TEMP}/logcheck -check-contextual ${CSI_LIB_UTIL_ROOT}/..."
+echo "Verifying logcheck: ${CSI_LIB_UTIL_TEMP}/logcheck -check-contextual ${CSI_LIB_UTIL_ROOT}/..."
 "${CSI_LIB_UTIL_TEMP}/logcheck" -check-contextual -check-with-helpers "${CSI_LIB_UTIL_ROOT}/..."


### PR DESCRIPTION
The `Check for spelling errors` test is currently failing due to the presence of typos.
You can see the failing test run here:
https://github.com/kubernetes-csi/external-snapshotter/actions/runs/9035364170/job/24829958236?pr=1083
