### PR TITLE
pull-test.sh: fix "git subtree pull" errors

### DIFF
--- a/pull-test.sh
+++ b/pull-test.sh
@@ -20,6 +20,11 @@
 
 set -ex
 
+# Prow checks out repos with --filter=blob:none. This breaks
+# "git subtree pull" unless we enable fetching missing file content.
+GIT_NO_LAZY_FETCH=0
+export GIT_NO_LAZY_FETCH
+
 # It must be called inside the updated csi-release-tools repo.
 CSI_RELEASE_TOOLS_DIR="$(pwd)"
 


### PR DESCRIPTION
Without allowing to fetch missing file content, "git subtree pull" fails:

    remote: warning: lazy fetching disabled; some objects may not be available
    remote: fatal: could not fetch b18c53581356c52a220a2baf1c8cf3fd9c57dda6 from promisor remote
    error: git upload-pack: git-pack-objects died with error.
    fatal: git upload-pack: aborting due to possible repository corruption on the remote side.
    remote: aborting due to possible repository corruption on the remote side.�
    fatal: protocol error: bad pack header