### PR TITLE
Set GOMODCACHE to avoid re-download toolchain

### DIFF
--- a/prow.sh
+++ b/prow.sh
@@ -441,7 +441,8 @@ run_with_go () {
     else
         version=local
     fi
-    GOTOOLCHAIN=$version run "$@"
+    # Set GOMODCACHE to make sure Kubernetes does not need to download again.
+    GOTOOLCHAIN=$version GOMODCACHE="$(go env GOMODCACHE)" run "$@"
 }
 
 # Ensure that we have the desired version of kind.


### PR DESCRIPTION
If we don't set this, k/k build script will set GOMODCACHE different from default, and re-download the toolchain (or fail to build for Kubernetes <= 1.29).

/release-note-none