### PR TITLE
feat: support windows hostprocess image build

### DIFF
--- a/build.make
+++ b/build.make
@@ -153,6 +153,7 @@ $(CMDS:%=push-multiarch-%): push-multiarch-%: check-pull-base-ref build-%
 	trap "docker buildx rm multiarchimage-buildertest" EXIT; \
 	dockerfile_linux=$$(if [ -e ./$(CMDS_DIR)/$*/Dockerfile ]; then echo ./$(CMDS_DIR)/$*/Dockerfile; else echo Dockerfile; fi); \
 	dockerfile_windows=$$(if [ -e ./$(CMDS_DIR)/$*/Dockerfile.Windows ]; then echo ./$(CMDS_DIR)/$*/Dockerfile.Windows; else echo Dockerfile.Windows; fi); \
+	dockerfile_windows_hp=$$(if [ -e ./$(CMDS_DIR)/$*/Dockerfile.WindowsHostProcess ]; then echo ./$(CMDS_DIR)/$*/Dockerfile.WindowsHostProcess; else echo Dockerfile.WindowsHostProcess; fi); \
 	if [ '$(BUILD_PLATFORMS)' ]; then build_platforms='$(BUILD_PLATFORMS)'; else build_platforms="linux amd64"; fi; \
 	if ! [ -f "$$dockerfile_windows" ]; then \
 		build_platforms="$$(echo "$$build_platforms" | sed -e 's/windows *[^ ]* *[^ ]* *.exe *[^ ]* *[^ ]*//g' -e 's/; *;/;/g' -e 's/;[ ]*$$//')"; \
@@ -191,6 +192,17 @@ $(CMDS:%=push-multiarch-%): push-multiarch-%: check-pull-base-ref build-%
 			fi; \
 		done; \
 		docker manifest push -p $(IMAGE_NAME):$$tag; \
+		if [ -f "$$dockerfile_windows_hp" ]; then \
+			docker buildx build --push \
+				--tag $(IMAGE_NAME):$$tag-amd64-windows-hp \
+				--platform=windows/amd64 \
+				--file $$dockerfile_windows_hp \
+				--build-arg binary=./bin/$*.exe \
+				--label revision=$(REV) \
+				.; \
+			docker manifest create --amend $(IMAGE_NAME):$$tag-windows-hp $(IMAGE_NAME):$$tag-amd64-windows-hp; \
+			docker manifest push -p $(IMAGE_NAME):$$tag-windows-hp; \
+		fi; \
 	}; \
 	if [ $(PULL_BASE_REF) = "master" ] || [ $(PULL_BASE_REF) = "main" ]; then \
 			: "creating or overwriting canary image"; \


### PR DESCRIPTION
this PR adds support for [windows hostprocess image](https://kubernetes.io/docs/tasks/configure-pod-container/create-hostprocess-pod/) build, the windows hostprocess image is used for the host process deployment, the image container could run on both windows 1809 and 2022 (and 2025 in the future)
so this PR builds one dedicated image(`$ver-windows-hp`) for the host process deployment. For keeping backward compatibility, we need to keep the original windows image build, e.g. for smb csi driver image, we need to keep `amd64-windows-nanoserver-ltsc2022` and `amd64-windows-nanoserver-1809` tags, so for this PR, I have added a new tag `$ver-windows-hp` dedicated for hostprocess image.

following image has been successfully built in smb csi driver: 
gcr.io/k8s-staging-sig-storage/smbplugin:canary-windows-hp