### PR TITLE
WIP: Move staging repo away from gcr.io

### DIFF
--- a/SIDECAR_RELEASE_PROCESS.md
+++ b/SIDECAR_RELEASE_PROCESS.md
@@ -130,7 +130,7 @@ https://prow.k8s.io/?job=canary-csi-test-push-images
 
 #### Verify images
 
-Canary and staged images can be viewed at https://console.cloud.google.com/gcr/images/k8s-staging-sig-storage
+Canary and staged images can be viewed at https://console.cloud.google.com/artifacts/docker/k8s-staging-sig-storage
 
 Promoted images can be viewed at https://console.cloud.google.com/gcr/images/k8s-artifacts-prod/us/sig-storage
 

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -31,7 +31,7 @@ steps:
     env:
     - GIT_TAG=${_GIT_TAG}
     - PULL_BASE_REF=${_PULL_BASE_REF}
-    - REGISTRY_NAME=gcr.io/${_STAGING_PROJECT}
+    - REGISTRY_NAME=us-central1-docker.pkg.dev/${_STAGING_PROJECT}
     - HOME=/root
 substitutions:
   # _GIT_TAG will be filled with a git-based tag for the image, of the form vYYYYMMDD-hash, and
@@ -40,8 +40,8 @@ substitutions:
   # _PULL_BASE_REF will contain the ref that was pushed to trigger this build -
   # a branch like 'master' or 'release-0.2', or a tag like 'v0.2'.
   _PULL_BASE_REF: 'master'
-  # The default gcr.io staging project for Kubernetes-CSI
-  # (=> https://console.cloud.google.com/gcr/images/k8s-staging-sig-storage/GLOBAL).
+  # The default us-central1-docker.pkg.dev staging project for Kubernetes-CSI
+  # (=> https://console.cloud.google.com/artifacts/docker/k8s-staging-sig-storage/us-central1).
   # Might be overridden in the Prow build job for a repo which wants
   # images elsewhere.
   _STAGING_PROJECT: 'k8s-staging-sig-storage'

--- a/prow.sh
+++ b/prow.sh
@@ -218,7 +218,7 @@ configvar CSI_PROW_DRIVER_CANARY "${CSI_PROW_HOSTPATH_CANARY}" "driver image ove
 
 # Image registry to use for canary images.
 # Only valid if CSI_PROW_DRIVER_CANARY == "canary".
-configvar CSI_PROW_DRIVER_CANARY_REGISTRY "gcr.io/k8s-staging-sig-storage" "registry for canary images"
+configvar CSI_PROW_DRIVER_CANARY_REGISTRY "us-central1-docker.pkg.dev/k8s-staging-sig-storage" "registry for canary images"
 
 # The E2E testing can come from an arbitrary repo. The expectation is that
 # the repo supports "go test ./test/e2e -args --storage.testdriver" (https://github.com/kubernetes/kubernetes/pull/72836)
@@ -954,13 +954,13 @@ patch_kubernetes () {
     local source="$1" target="$2"
 
     if [ "${CSI_PROW_DRIVER_CANARY}" = "canary" ]; then
-        # We cannot replace registry.k8s.io/sig-storage with gcr.io/k8s-staging-sig-storage because
+        # We cannot replace registry.k8s.io/sig-storage with us-central1-docker.pkg.dev/k8s-staging-sig-storage because
         # e2e.test does not support it (see test/utils/image/manifest.go). Instead we
         # invoke the e2e.test binary with KUBE_TEST_REPO_LIST set to a file that
         # overrides that registry.
         find "$source/test/e2e/testing-manifests/storage-csi/mock" -name '*.yaml' -print0 | xargs -0 sed -i -e 's;registry.k8s.io/sig-storage/\(.*\):v.*;registry.k8s.io/sig-storage/\1:canary;'
         cat >"$target/e2e-repo-list" <<EOF
-sigStorageRegistry: gcr.io/k8s-staging-sig-storage
+sigStorageRegistry: us-central1-docker.pkg.dev/k8s-staging-sig-storage
 EOF
         cat >&2 <<EOF
 


### PR DESCRIPTION
As stated here https://cloud.google.com/artifact-registry/docs/transition/transition-from-gcr, gcr Container Registry will be shut down after March 18, 2025. We need to move our staging repo away from gcr.io.

Images on staging repo can be viewed here after we moved over:
https://console.cloud.google.com/artifacts/docker/k8s-staging-sig-storage