### PR TITLE
Bump golang to 1.23.6 to fix CVE-2024-45336, CVE-2025-22866

### DIFF
--- a/prow.sh
+++ b/prow.sh
@@ -86,7 +86,7 @@ configvar CSI_PROW_BUILD_PLATFORMS "linux amd64 amd64; linux ppc64le ppc64le -pp
 # which is disabled with GOFLAGS=-mod=vendor).
 configvar GOFLAGS_VENDOR "$( [ -d vendor ] && echo '-mod=vendor' )" "Go flags for using the vendor directory"
 
-configvar CSI_PROW_GO_VERSION_BUILD "1.23.1" "Go version for building the component" # depends on component's source code
+configvar CSI_PROW_GO_VERSION_BUILD "1.23.6" "Go version for building the component" # depends on component's source code
 configvar CSI_PROW_GO_VERSION_E2E "" "override Go version for building the Kubernetes E2E test suite" # normally doesn't need to be set, see install_e2e
 configvar CSI_PROW_GO_VERSION_SANITY "${CSI_PROW_GO_VERSION_BUILD}" "Go version for building the csi-sanity test suite" # depends on CSI_PROW_SANITY settings below
 configvar CSI_PROW_GO_VERSION_KIND "${CSI_PROW_GO_VERSION_BUILD}" "Go version for building 'kind'" # depends on CSI_PROW_KIND_VERSION below


### PR DESCRIPTION
```
─────────┬────────────────┬──────────┬────────┬───────────────────┬─────────────────────────────┬──────────────────────────────────────────────────────────────┐
│ Library │ Vulnerability  │ Severity │ Status │ Installed Version │        Fixed Version        │                            Title                             │
├─────────┼────────────────┼──────────┼────────┼───────────────────┼─────────────────────────────┼──────────────────────────────────────────────────────────────┤
│ stdlib  │ CVE-2024-45336 │ MEDIUM   │ fixed  │ v1.23.1           │ 1.22.11, 1.23.5, 1.24.0-rc2 │ golang: net/http: net/http: sensitive headers incorrectly    │
│         │                │          │        │                   │                             │ sent after cross-domain redirect                             │
│         │                │          │        │                   │                             │ https://avd.aquasec.com/nvd/cve-2024-45336                   │
│         ├────────────────┤          │        │                   │                             ├──────────────────────────────────────────────────────────────┤
│         │ CVE-2024-45341 │          │        │                   │                             │ golang: crypto/x509: crypto/x509: usage of IPv6 zone IDs can │
│         │                │          │        │                   │                             │ bypass URI name...                                           │
│         │                │          │        │                   │                             │ https://avd.aquasec.com/nvd/cve-2024-45341                   │
└─────────┴────────────────┴──────────┴────────┴───────────────────┴─────────────────────────────┴──────────────────────────────────────────────────────────────┘
```

**Release note**:
```release-note
Bump golang to 1.23.6 to fix CVE-2024-45336, CVE-2025-22866
```