### PR TITLE
Fix support dates for CSI sidecars

### DIFF
--- a/contrib/get_supported_version_csi-sidecar.py
+++ b/contrib/get_supported_version_csi-sidecar.py
@@ -74,9 +74,9 @@ def end_of_life_grouped_versions(versions):
     """
     supported_versions = []
     # Prepare dates for later calculation
-    now          = datetime.datetime.now()
-    one_year     = datetime.timedelta(days=365)
-    three_months = datetime.timedelta(days=90)
+    now          = datetime.date.today()
+    one_year     = now - relativedelta(years=1)
+    three_months = now - relativedelta(months=3)
 
     # get the newer versions on top
     sorted_versions_list = sorted(versions.items(), key=lambda x: x[0], reverse=True)
@@ -89,10 +89,10 @@ def end_of_life_grouped_versions(versions):
         first_release = v[1][-1]
         last_release  = v[1][0]
         # if the release is less than a year old we support the latest patch version
-        if now - first_release[1] < one_year:
+        if first_release[1] >= one_year:
             supported_versions.append(last_release)
-        # if the main release is older than a year and has a recent path, this is supported
-        elif now - last_release[1] < three_months:
+        # if the main release is older than a year and has a recent patch, this is supported
+        elif last_release[1] >= three_months:
             supported_versions.append(last_release)
     return supported_versions
 
@@ -109,7 +109,7 @@ def get_release_docker_image(repo, version):
 def get_versions_from_releases(repo):
     """
     Using `gh` cli get the github releases page details then
-    create a list of grouped version on major.minor 
+    create a list of grouped version on major.minor
     and for each give all major.minor.patch with release dates
     """
     # Run the `gh release` command to get the release list
@@ -125,7 +125,7 @@ def get_versions_from_releases(repo):
             continue
         major, minor, patch = parsed_version
 
-        published = datetime.datetime.strptime(parts[3], '%Y-%m-%dT%H:%M:%SZ')
+        published = datetime.datetime.strptime(parts[3], '%Y-%m-%dT%H:%M:%SZ').date()
         versions[(major, minor)].append((version, published))
     return(versions)
 


### PR DESCRIPTION
- Supported releases should probably be done by day, rather than changing on the time of day.
- Use 1 year and 3 months as stated in https://kubernetes-csi.github.io/docs/project-policies.html#support, rather than 365 days and 90 days, which are not quite the same.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
This file references the support timelines as detailed in https://kubernetes-csi.github.io/docs/project-policies.html#support. This says:
> The Kubernetes CSI project follows the broader Kubernetes project on support. Every minor release branch will be supported with patch releases on an as-needed basis for at least 1 year, starting with the first release of that minor version. In addition, the minor release branch will be supported for at least 3 months after the next minor version is released, to allow time to integrate with the latest release.

The code in this file uses 365 days as 1 year, and 90 days as 3 months, which is close but not quite the same. Using `relativedelta` enables us to get the dates exactly correct, even on leap years and more often for the 3 month cases.

This is quite minor (and probably a bit nit-picking!) but I also know of some automated checkers that don't like having references to 1 year and 365 days on the same line - as they're not the same! I'm having to patch this locally due to this, but thought I'd contribute it back upstream as it's easy.

Key decisions made that should be considered during review:
* I'm using dates, not datetimes. The support of a release probably shouldn't depend on the time of day?
* If a release was released on this day a year ago, it's still supported. i.e., a first release of 28th April 2024 will be supported on 28th April 2025, but not on 29th April 2025.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
No current issues are fixed by this PR. Would it help if I raised one? I thought not at this point.

**Special notes for your reviewer**:
I have tested this with no changes in supported releases. Testing this file is rather specific to the current date! I have used faketime to test this on a variety of dates.
```
csi-release-tools fix-support-dates$ python3 ./contrib/get_supported_version_csi-sidecar.py -R kubernetes-csi/external-health-monitor
Supported versions with release date and age of `kubernetes-csi/external-health-monitor`:

v0.14.0 2024-12-20      4 months ago
v0.13.0 2024-08-28      8 months ago
v0.12.1 2024-06-04      10 months ago

csi-release-tools fix-support-dates$ faketime "2025-05-24" python3 ./contrib/get_supported_version_csi-sidecar.py -R kubernetes-csi/external-health-monitor
Supported versions with release date and age of `kubernetes-csi/external-health-monitor`:

v0.14.0 2024-12-20      5 months ago
v0.13.0 2024-08-28      8 months ago
v0.12.1 2024-06-04      11 months ago

csi-release-tools fix-support-dates$ faketime "2025-05-25" python3 ./contrib/get_supported_version_csi-sidecar.py -R kubernetes-csi/external-health-monitor
Supported versions with release date and age of `kubernetes-csi/external-health-monitor`:

v0.14.0 2024-12-20      5 months ago
v0.13.0 2024-08-28      8 months ago
```
v0.12.1 drops support on 2025-05-25 because v0.12.0 was released on 2024-05-24, so 2025-05-24 is the last supported day.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
none
```
