### PR TITLE
fix: Update Go version from 1.25.8 to 1.25.9

### DIFF
--- a/prow.sh
+++ b/prow.sh
@@ -86,7 +86,7 @@ configvar CSI_PROW_BUILD_PLATFORMS "linux amd64 amd64; linux ppc64le ppc64le -pp
 # which is disabled with GOFLAGS=-mod=vendor).
 configvar GOFLAGS_VENDOR "$( [ -d vendor ] && echo '-mod=vendor' )" "Go flags for using the vendor directory"
 
-configvar CSI_PROW_GO_VERSION_BUILD "1.25.8" "Go version for building the component" # depends on component's source code
+configvar CSI_PROW_GO_VERSION_BUILD "1.25.9" "Go version for building the component" # depends on component's source code
 configvar CSI_PROW_GO_VERSION_E2E "" "override Go version for building the Kubernetes E2E test suite" # normally doesn't need to be set, see install_e2e
 configvar CSI_PROW_GO_VERSION_SANITY "${CSI_PROW_GO_VERSION_BUILD}" "Go version for building the csi-sanity test suite" # depends on CSI_PROW_SANITY settings below
 configvar CSI_PROW_GO_VERSION_KIND "${CSI_PROW_GO_VERSION_BUILD}" "Go version for building 'kind'" # depends on CSI_PROW_KIND_VERSION below


### PR DESCRIPTION
```
┌─────────┬────────────────┬──────────┬────────┬───────────────────┬────────────────┬─────────────────────────────────────────────────────────────┐
│ Library │ Vulnerability  │ Severity │ Status │ Installed Version │ Fixed Version  │                            Title                            │
├─────────┼────────────────┼──────────┼────────┼───────────────────┼────────────────┼─────────────────────────────────────────────────────────────┤
│ stdlib  │ CVE-2026-32280 │ UNKNOWN  │ fixed  │ v1.25.8           │ 1.25.9, 1.26.2 │ Unexpected work during chain building in crypto/x509        │
│         │                │          │        │                   │                │ https://avd.aquasec.com/nvd/cve-2026-32280                  │
│         ├────────────────┤          │        │                   │                ├─────────────────────────────────────────────────────────────┤
│         │ CVE-2026-32281 │          │        │                   │                │ Inefficient policy validation in crypto/x509                │
│         │                │          │        │                   │                │ https://avd.aquasec.com/nvd/cve-2026-32281                  │
│         ├────────────────┤          │        │                   │                ├─────────────────────────────────────────────────────────────┤
│         │ CVE-2026-32282 │          │        │                   │                │ TOCTOU permits root escape on Linux via Root.Chmod in os in │
│         │                │          │        │                   │                │ internal/syscall/unix...                                    │
│         │                │          │        │                   │                │ https://avd.aquasec.com/nvd/cve-2026-32282                  │
│         ├────────────────┤          │        │                   │                ├─────────────────────────────────────────────────────────────┤
│         │ CVE-2026-32283 │          │        │                   │                │ Unauthenticated TLS 1.3 KeyUpdate record can cause          │
│         │                │          │        │                   │                │ persistent connection retention and DoS...                  │
│         │                │          │        │                   │                │ https://avd.aquasec.com/nvd/cve-2026-32283                  │
│         ├────────────────┤          │        │                   │                ├─────────────────────────────────────────────────────────────┤
│         │ CVE-2026-32288 │          │        │                   │                │ Unbounded allocation for old GNU sparse in archive/tar      │
│         │                │          │        │                   │                │ https://avd.aquasec.com/nvd/cve-2026-32288                  │
│         ├────────────────┤          │        │                   │                ├─────────────────────────────────────────────────────────────┤
│         │ CVE-2026-32289 │          │        │                   │                │ JsBraceDepth Context Tracking Bugs (XSS) in html/template   │
│         │                │          │        │                   │                │ https://avd.aquasec.com/nvd/cve-2026-32289                  │
└─────────┴────────────────┴──────────┴────────┴───────────────────┴────────────────┴─────────────────────────────────────────────────────────────┘
```

**Release note**:
```
fix: Update Go version from 1.25.8 to 1.25.9
```