### PR TITLE
Add riscv64 (linux) to CSI_PROW_BUILD_PLATFORMS

### DIFF
--- a/prow.sh
+++ b/prow.sh
@@ -78,7 +78,7 @@ version_to_git () {
 # the list of windows versions was matched from:
 # - https://hub.docker.com/_/microsoft-windows-nanoserver
 # - https://hub.docker.com/_/microsoft-windows-servercore
-configvar CSI_PROW_BUILD_PLATFORMS "linux amd64 amd64; linux ppc64le ppc64le -ppc64le; linux s390x s390x -s390x; linux arm arm -arm; linux arm64 arm64 -arm64; linux arm arm/v7 -armv7; windows amd64 amd64 .exe nanoserver:1809 servercore:ltsc2019; windows amd64 amd64 .exe nanoserver:ltsc2022 servercore:ltsc2022" "Go target platforms (= GOOS + GOARCH) and file suffix of the resulting binaries"
+configvar CSI_PROW_BUILD_PLATFORMS "linux amd64 amd64; linux ppc64le ppc64le -ppc64le; linux s390x s390x -s390x; linux arm arm -arm; linux arm64 arm64 -arm64; linux arm arm/v7 -armv7; linux riscv64 riscv64 -riscv64; windows amd64 amd64 .exe nanoserver:1809 servercore:ltsc2019; windows amd64 amd64 .exe nanoserver:ltsc2022 servercore:ltsc2022" "Go target platforms (= GOOS + GOARCH) and file suffix of the resulting binaries"
 
 # If we have a vendor directory, then use it. We must be careful to only
 # use this for "make" invocations inside the project's repo itself because


### PR DESCRIPTION
## What type of PR is this?

/kind feature

## What this PR does / why we need it:

Add `linux riscv64` to the default `CSI_PROW_BUILD_PLATFORMS` in `prow.sh` so that all CSI sidecar repos that consume csi-release-tools automatically build and publish riscv64 images.

Now that riscv64 support is available for the distroless Docker base image ([GoogleContainerTools/distroless#2001](https://github.com/GoogleContainerTools/distroless/pull/2001)), riscv64 can be added as a supported architecture across the CSI ecosystem.

This was requested in:
- https://github.com/kubernetes-csi/livenessprobe/pull/403#issuecomment-2780908205 (by @carlory)
- https://github.com/kubernetes-csi/external-provisioner/pull/1481

## Which issue(s) this PR fixes:

Related to kubernetes-csi/livenessprobe#403
Related to kubernetes-csi/external-provisioner#1481

## Special notes for your reviewer:

This is a one-line change to `prow.sh` line 81, adding `linux riscv64 riscv64 -riscv64` to the platform list (following the same pattern as other architectures).

## Does this PR introduce a user-facing change?

```release-note
Support added for architecture riscv64 (linux) in CSI sidecar builds.
```