### PR TITLE
chore: bump Go version to 1.25.10 in prow.sh

### DIFF
--- a/prow.sh
+++ b/prow.sh
@@ -86,7 +86,7 @@ configvar CSI_PROW_BUILD_PLATFORMS "linux amd64 amd64; linux ppc64le ppc64le -pp
 # which is disabled with GOFLAGS=-mod=vendor).
 configvar GOFLAGS_VENDOR "$( [ -d vendor ] && echo '-mod=vendor' )" "Go flags for using the vendor directory"
 
-configvar CSI_PROW_GO_VERSION_BUILD "1.25.9" "Go version for building the component" # depends on component's source code
+configvar CSI_PROW_GO_VERSION_BUILD "1.25.10" "Go version for building the component" # depends on component's source code
 configvar CSI_PROW_GO_VERSION_E2E "" "override Go version for building the Kubernetes E2E test suite" # normally doesn't need to be set, see install_e2e
 configvar CSI_PROW_GO_VERSION_SANITY "${CSI_PROW_GO_VERSION_BUILD}" "Go version for building the csi-sanity test suite" # depends on CSI_PROW_SANITY settings below
 configvar CSI_PROW_GO_VERSION_KIND "${CSI_PROW_GO_VERSION_BUILD}" "Go version for building 'kind'" # depends on CSI_PROW_KIND_VERSION below


### PR DESCRIPTION
## What this PR does

Bumps CSI_PROW_GO_VERSION_BUILD from 1.25.9 to 1.25.10 in prow.sh.

this is for fixing following CVEs:
```
Total: 8 (UNKNOWN: 8, MEDIUM: 0, HIGH: 0, CRITICAL: 0)

┌─────────┬────────────────┬──────────┬────────┬───────────────────┬─────────────────┬─────────────────────────────────────────────────────────────┐
│ Library │ Vulnerability  │ Severity │ Status │ Installed Version │  Fixed Version  │                            Title                            │
├─────────┼────────────────┼──────────┼────────┼───────────────────┼─────────────────┼─────────────────────────────────────────────────────────────┤
│ stdlib  │ CVE-2026-33811 │ UNKNOWN  │ fixed  │ v1.26.1           │ 1.25.10, 1.26.3 │ Crash when handling long CNAME response in net              │
│         │                │          │        │                   │                 │ https://avd.aquasec.com/nvd/cve-2026-33811                  │
│         ├────────────────┤          │        │                   │                 ├─────────────────────────────────────────────────────────────┤
│         │ CVE-2026-33814 │          │        │                   │                 │ Infinite loop in HTTP/2 transport when given bad            │
│         │                │          │        │                   │                 │ SETTINGS_MAX_FRAME_SIZE in net/http/internal/http2 in...    │
│         │                │          │        │                   │                 │ https://avd.aquasec.com/nvd/cve-2026-33814                  │
│         ├────────────────┤          │        │                   │                 ├─────────────────────────────────────────────────────────────┤
│         │ CVE-2026-39820 │          │        │                   │                 │ Quadratic string concatentation in consumeComment in        │
│         │                │          │        │                   │                 │ net/mail                                                    │
│         │                │          │        │                   │                 │ https://avd.aquasec.com/nvd/cve-2026-39820                  │
│         ├────────────────┤          │        │                   │                 ├─────────────────────────────────────────────────────────────┤
│         │ CVE-2026-39823 │          │        │                   │                 │ Bypass of meta content URL escaping causes XSS in           │
│         │                │          │        │                   │                 │ html/template                                               │
│         │                │          │        │                   │                 │ https://avd.aquasec.com/nvd/cve-2026-39823                  │
│         ├────────────────┤          │        │                   │                 ├─────────────────────────────────────────────────────────────┤
│         │ CVE-2026-39825 │          │        │                   │                 │ ReverseProxy forwards queries with more than                │
│         │                │          │        │                   │                 │ urlmaxqueryparams parameters in net/http/httputil           │
│         │                │          │        │                   │                 │ https://avd.aquasec.com/nvd/cve-2026-39825                  │
│         ├────────────────┤          │        │                   │                 ├─────────────────────────────────────────────────────────────┤
│         │ CVE-2026-39826 │          │        │                   │                 │ Escaper bypass leads to XSS in html/template                │
│         │                │          │        │                   │                 │ https://avd.aquasec.com/nvd/cve-2026-39826                  │
│         ├────────────────┤          │        │                   │                 ├─────────────────────────────────────────────────────────────┤
│         │ CVE-2026-39836 │          │        │                   │                 │ Panic in Dial and LookupPort when handling NUL byte on      │
│         │                │          │        │                   │                 │ Windows in...                                               │
│         │                │          │        │                   │                 │ https://avd.aquasec.com/nvd/cve-2026-39836                  │
│         ├────────────────┤          │        │                   │                 ├─────────────────────────────────────────────────────────────┤
│         │ CVE-2026-42499 │          │        │                   │                 │ Quadratic string concatenation in consumePhrase in net/mail │
│         │                │          │        │                   │                 │ https://avd.aquasec.com/nvd/cve-2026-42499                  │
└─────────┴────────────────┴──────────┴────────┴───────────────────┴─────────────────┴────────────────────────────────────────────────────
```

/kind bug