### PR TITLE
Verify subtree contents instead of merge history

### DIFF
--- a/verify-subtree.sh
+++ b/verify-subtree.sh
@@ -14,28 +14,43 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# This script verifies that the content of a directory managed
-# by "git subtree" has not been modified locally. It does that
-# by looking for commits that modify the files with the
-# subtree prefix (aka directory) while ignoring merge
-# commits. Merge commits are where "git subtree" pulls the
-# upstream files into the directory.
+# Verify that DIR is a clean copy of upstream csi-release-tools.
 #
-# Theoretically a developer can subvert this check by modifying files
-# in a merge commit, but in practice that shouldn't happen.
+# We read the upstream SHA from the "git-subtree-split" line that
+# "git subtree" writes into the pull commit's message, fetch that
+# SHA, and require its tree to equal HEAD:DIR.
 
 DIR="$1"
-if [ ! "$DIR" ]; then
+if [ -z "$DIR" ]; then
     echo "usage: $0 <directory>" >&2
     exit 1
 fi
 
-REV=$(git log -n1 --remove-empty --format=format:%H --no-merges -- "$DIR")
-if [ "$REV" ]; then
-    echo "Directory '$DIR' contains non-upstream changes:"
-    echo
-    git log --no-merges -- "$DIR"
+# csi-release-tools itself does not contain release-tools/.
+[ -d "$DIR" ] || exit 0
+
+UPSTREAM_URL="${UPSTREAM_URL:-https://github.com/kubernetes-csi/csi-release-tools.git}"
+
+REV=$(git log -1 --grep="^git-subtree-dir: $DIR\$" --format=%H)
+if [ -z "$REV" ]; then
+    echo "No subtree pull recorded for '$DIR'." >&2
     exit 1
-else
-    echo "$DIR is a clean copy of upstream."
 fi
+
+# A squashed PR with multiple pulls carries one trailer block per pull; the last one is HEAD.
+SPLIT=$(git log -1 --format=%B "$REV" | grep '^git-subtree-split: ' | tail -1 | cut -d' ' -f2)
+if [ -z "$SPLIT" ]; then
+    echo "Subtree commit $REV has no git-subtree-split trailer." >&2
+    exit 1
+fi
+
+git fetch --quiet --no-tags "$UPSTREAM_URL" "$SPLIT"
+
+if [ "$(git rev-parse "HEAD:$DIR")" = "$(git rev-parse "$SPLIT^{tree}")" ]; then
+    echo "$DIR matches upstream at $SPLIT."
+    exit 0
+fi
+
+echo "$DIR diverges from upstream at $SPLIT:" >&2
+git diff --stat "$SPLIT" "HEAD:$DIR" >&2
+exit 1


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

[verify-subtree.sh](https://github.com/kubernetes-csi/csi-release-tools/blob/master/verify-subtree.sh) rejects any non-merge commits that touches `release-tools/` on the assumption that subtree pulls always land as merge commits. This assumption breaks when, for example, a PR carrying a subtree pull is squash-merged. In that scenario, the result is a single non-merge commit, which causes the test to fail and every subsequent PR is blocked even though `release-tools/` matches upstream.

This PR fixes the script to check the property we actualy care about here, which is `release-tools/` having the same contents as upstream. We do this by fetching the SHA and comparing the trees - if they match, good, if not, print a diff so the reviewer/contributor can see what's off. As a bonus this also catches edits snuck in via merge commits which the old check was letting through (see notes below).

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->

This happed on https://github.com/kubernetes-csi/csi-lib-utils/pull/213 and is currently blocking https://github.com/kubernetes-csi/csi-lib-utils/pull/214.

Fixes # https://github.com/kubernetes-csi/csi-release-tools/issues/304

**Special notes for your reviewer**:

For testing, i ran the new script against consuming repo's master and most recent release branch and it surfaced two issues:

  1. [`kubernetes-csi/csi-proxy/release-tools/prow.sh#L1267`](https://github.com/kubernetes-csi/csi-proxy/blob/master/release-tools/prow.sh#L1267) - diff at `"BUILD_PLATFORMS=${CSI_PROW_BUILD_PLATFORMS}"`
  2. [`kubernetes-csi/csi-driver-smb/release-tools/build.make#L156`](https://github.com/kubernetes-csi/csi-driver-smb/blob/master/release-tools/build.make#L156) and [`#L195-L204`](https://github.com/kubernetes-csi/csi-driver-smb/blob/master/release-tools/build.make#L195-L204). - Windows HostProcess container build steps diff.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
