### PR TITLE
Remove go deb / Gopkg.toml handling in verify-vendor.

### DIFF
--- a/verify-vendor.sh
+++ b/verify-vendor.sh
@@ -14,19 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-if [ -f Gopkg.toml ]; then
-    echo "Repo uses 'dep' for vendoring."
-    case "$(dep version 2>/dev/null | grep 'version *:')" in
-	*v0.[56789]*)
-            if dep check; then
-                echo "vendor up-to-date"
-            else
-                exit 1
-            fi
-            ;;
-	*) echo "skipping check, dep >= 0.5 required";;
-    esac
-elif [ -f go.mod ]; then
+if [ -f go.mod ]; then
     echo "Repo uses 'go mod'."
     # shellcheck disable=SC2235
     if [ "${JOB_NAME}" ] &&


### PR DESCRIPTION
The current go dep handling introduces a supply chain attack:

* Create a pull request against the target repository.

* Modify a vendored dependency in the vendor/ directory to include a malicious payload or backdoor.

* Add an empty file named Gopkg.toml to the root of the repository.

* Commit and push the changes. Observe that the CI verify-vendor.sh script outputs 'skipping check, dep >= 0.5 required' and exits with a success status, bypassing the go mod vendor checks.

No kubernetes-csi repo uses this tool: https://github.com/search?q=org%3Akubernetes-csi+path%3A**%2FGopkg.toml&type=code

Go dep has been deprecated since 2020
(https://github.com/golang/go/issues/38158). Removing this support will make future maintenance easier.

```release-note
Remove go dep / Gopkg.toml support from verify-vendor.sh
```
