### PR TITLE
Escape user controlled input in prow.sh

### DIFF
--- a/prow.sh
+++ b/prow.sh
@@ -853,7 +853,8 @@ install_snapshot_controller() {
 
                   # Now replace registry and/or tag
                   NEW_TAG="csiprow"
-                  line="$(echo "$nocomments" | sed -e "s;$image;${name}:${NEW_TAG};")"
+                  escaped_image=$(printf '%s\n' "$image" | sed -e 's/[\/&;]/\\&/g')
+                  line="$(echo "$nocomments" | sed -e "s;${escaped_image};${name}:${NEW_TAG};")"
 	          echo "        using $line" >&2
               fi
               echo "$line"


### PR DESCRIPTION
An attacker submitting a malicious Pull Request can execute arbitrary shell commands inside the CI runner container.

The snapshot controller yaml from an untrusted pull request is read line by line, and the image: value is extracted into '$image' without any escaping or sanitization.  This varible is then used directly ina double-quoted 'sed -e' command string, allowing the user to break out of the 's' command using ';' and execute arbitrary 'sed' extensions like 'e' (execute shell command).

```release-note
Escape user-supplied image string in prow.sh
```