### PR TITLE
Update Go version from 1.26.5 to 1.26.6 to fix CVEs

### DIFF
--- a/prow.sh
+++ b/prow.sh
@@ -86,7 +86,7 @@ configvar CSI_PROW_BUILD_PLATFORMS "linux amd64 amd64; linux ppc64le ppc64le -pp
 # which is disabled with GOFLAGS=-mod=vendor).
 configvar GOFLAGS_VENDOR "$( [ -d vendor ] && echo '-mod=vendor' )" "Go flags for using the vendor directory"
 
-configvar CSI_PROW_GO_VERSION_BUILD "1.26.5" "Go version for building the component" # depends on component's source code
+configvar CSI_PROW_GO_VERSION_BUILD "1.26.6" "Go version for building the component" # depends on component's source code
 configvar CSI_PROW_GO_VERSION_E2E "" "override Go version for building the Kubernetes E2E test suite" # normally doesn't need to be set, see install_e2e
 configvar CSI_PROW_GO_VERSION_SANITY "${CSI_PROW_GO_VERSION_BUILD}" "Go version for building the csi-sanity test suite" # depends on CSI_PROW_SANITY settings below
 configvar CSI_PROW_GO_VERSION_KIND "${CSI_PROW_GO_VERSION_BUILD}" "Go version for building 'kind'" # depends on CSI_PROW_KIND_VERSION below


### PR DESCRIPTION
```
┌─────────┬────────────────┬──────────┬────────┬───────────────────┬──────────────────────────────┬─────────────────────────────────────────────────────────────┐
  │ Library │ Vulnerability  │ Severity │ Status │ Installed Version │        Fixed Version         │                            Title                            │
  ├─────────┼────────────────┼──────────┼────────┼───────────────────┼──────────────────────────────┼─────────────────────────────────────────────────────────────┤
  │ stdlib  │ CVE-2026-39821 │ HIGH     │ fixed  │ v1.25.11          │ 1.25.13, 1.26.6, 1.27.0-rc.3 │ golang.org/x/net/idna: golang: net/http:                    │
  │         │                │          │        │                   │                              │ golang.org/x/net/idna: Privilege escalation via incorrect   │
  │         │                │          │        │                   │                              │ Punycode label processing                                   │
  │         │                │          │        │                   │                              │ https://avd.aquasec.com/nvd/cve-2026-39821                  │
  │         ├────────────────┼──────────┤        │                   │                              ├─────────────────────────────────────────────────────────────┤
  │         │ CVE-2026-33818 │ UNKNOWN  │        │                   │                              │ Enforce maximum recursion depth in encoding/asn1            │
  │         │                │          │        │                   │                              │ https://avd.aquasec.com/nvd/cve-2026-33818                  │
  │         ├────────────────┤          │        │                   │                              ├─────────────────────────────────────────────────────────────┤
  │         │ CVE-2026-56853 │          │        │                   │                              │ Apply ReadHeaderTimeout when doing unencrypted HTTP/2 check │
  │         │                │          │        │                   │                              │ in net/http                                                 │
  │         │                │          │        │                   │                              │ https://avd.aquasec.com/nvd/cve-2026-56853                  │
  │         ├────────────────┤          │        │                   │                              ├─────────────────────────────────────────────────────────────┤
  │         │ CVE-2026-56858 │          │        │                   │                              │ Fix Javascript regexp context tracking in html/template     │
  │         │                │          │        │                   │                              │ https://avd.aquasec.com/nvd/cve-2026-56858                  │
  │         ├────────────────┤          │        │                   │                              ├─────────────────────────────────────────────────────────────┤
  │         │ CVE-2026-56859 │          │        │                   │                              │ Add recursion depth guard during decode in encoding/xml     │
  │         │                │          │        │                   │                              │ https://avd.aquasec.com/nvd/cve-2026-56859                  │
  │         ├────────────────┤          │        │                   │                              ├─────────────────────────────────────────────────────────────┤
  │         │ CVE-2026-56860 │          │        │                   │                              │ Avoid quadratic complexity in resolvePath in net/url        │
  │         │                │          │        │                   │                              │ https://avd.aquasec.com/nvd/cve-2026-56860                  │
  │         ├────────────────┤          │        │                   │                              ├─────────────────────────────────────────────────────────────┤
  │         │ CVE-2026-56862 │          │        │                   │                              │ Limit handshake messages we are willing to accept           │
  │         │                │          │        │                   │                              │ post-handshake in crypto/tls                                │
  │         │                │          │        │                   │                              │ https://avd.aquasec.com/nvd/cve-2026-56862                  │
  └─────────┴────────────────┴──────────┴────────┴───────────────────┴──────────────────────────────┴─────────────────────────────────────────────────────────────┘
```

/kind bug
/release-note-none