### PR TITLE
OWNERS: remove pohly from kubernetes-csi-reviewers

### DIFF
--- a/KUBERNETES_CSI_OWNERS_ALIASES
+++ b/KUBERNETES_CSI_OWNERS_ALIASES
@@ -27,7 +27,6 @@ aliases:
   - j-griffith
   - jingxu97
   - jsafrane
-  - pohly
   - RaunakShah
   - sunnylovestiramisu
   - xing-yang


### PR DESCRIPTION
I've not been active enough for a while now to be listed among the default reviewers for CSI repos. I'm keeping myself listed as approver, just in case.

This needs to trickle down into the various CSI repose before it becomes effective more widely.
